### PR TITLE
Various fixes for time-stepping

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -4372,6 +4372,20 @@ public:
   su2double GetCurrent_UnstTime(void);
   
   /*!
+   * \brief If we are performing an unsteady simulation, this adds to the
+   * value of the current time.
+   * \param[in] Amount of time to be added (usually one time step)
+   */
+  su2double AddCurrent_UnstTime(su2double delta_time);
+
+  /*!
+   * \brief If we are performing an unsteady simulation, set the
+   *  value of current time.
+   * \param[in] val_time - Value of the physical time in an unsteady simulation.
+   */
+  void SetCurrent_UnstTime(su2double val_time);
+
+  /*!
    * \brief Divide the rectbles and hexahedron.
    * \return <code>TRUE</code> if the elements must be divided; otherwise <code>FALSE</code>.
    */

--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -4376,7 +4376,7 @@ public:
    * value of the current time.
    * \param[in] Amount of time to be added (usually one time step)
    */
-  su2double AddCurrent_UnstTime(su2double delta_time);
+  void AddCurrent_UnstTime(su2double delta_time);
 
   /*!
    * \brief If we are performing an unsteady simulation, set the

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -1191,7 +1191,7 @@ inline su2double CConfig::GetDelta_UnstTime(void) { return Delta_UnstTime; }
 
 inline su2double CConfig::GetCurrent_UnstTime(void) { return Current_UnstTime; }
 
-inline su2double CConfig::AddCurrent_UnstTime(su2double delta_time) { Current_UnstTime += delta_time; }
+inline void CConfig::AddCurrent_UnstTime(su2double delta_time) { Current_UnstTime += delta_time; }
 
 inline void CConfig::SetCurrent_UnstTime(su2double val_time) { Current_UnstTime = val_time; }
 

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -1191,6 +1191,10 @@ inline su2double CConfig::GetDelta_UnstTime(void) { return Delta_UnstTime; }
 
 inline su2double CConfig::GetCurrent_UnstTime(void) { return Current_UnstTime; }
 
+inline su2double CConfig::AddCurrent_UnstTime(su2double delta_time) { Current_UnstTime += delta_time; }
+
+inline void CConfig::SetCurrent_UnstTime(su2double val_time) { Current_UnstTime = val_time; }
+
 inline void CConfig::SetDelta_UnstTimeND(su2double val_delta_unsttimend) { Delta_UnstTimeND = val_delta_unsttimend; }
 
 inline su2double CConfig::GetTotal_UnstTime(void) { return Total_UnstTime; }

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -5933,8 +5933,15 @@ void CConfig::SetGlobalParam(unsigned short val_solver,
                              unsigned long val_extiter) {
 
   /*--- Set the simulation global time ---*/
-  Current_UnstTime = static_cast<su2double>(val_extiter)*Delta_UnstTime;
-  Current_UnstTimeND = static_cast<su2double>(val_extiter)*Delta_UnstTimeND;
+  switch (GetUnsteady_Simulation()) {
+    case TIME_STEPPING:
+      /*--- This is updated from the solver; Do nothing here. ---*/
+      break;
+    case DT_STEPPING_1ST: case DT_STEPPING_2ND:
+      /*--- Fixed time step used.  Just multiply by iterations. ---*/
+      Current_UnstTime = static_cast<su2double>(val_extiter)*Delta_UnstTime;
+      Current_UnstTimeND = static_cast<su2double>(val_extiter)*Delta_UnstTimeND;
+  }
 
   /*--- Set the solver methods ---*/
   switch (val_solver) {

--- a/SU2_CFD/src/integration_time.cpp
+++ b/SU2_CFD/src/integration_time.cpp
@@ -158,7 +158,12 @@ void CMultiGridIntegration::MultiGrid_Cycle(CGeometry ***geometry,
         
         solver_container[iZone][iMesh][SolContainer_Position]->Set_OldSolution(geometry[iZone][iMesh]);
         
-        /*--- Compute time step, max eigenvalue, and integration scheme (steady and unsteady problems) ---*/
+        /*--- Compute time step, max eigenvalue, and integration scheme
+         *    (steady and unsteady problems)
+         * XXX: Note that the timestep and timestep are only calculated once
+         * per each timestep.  This means that the "time" is not correctly
+         * set for any RK substeps, so any sources/sinks that depend explicitly
+         * on time will not be computed correctly. ---*/
         
         solver_container[iZone][iMesh][SolContainer_Position]->SetTime_Step(geometry[iZone][iMesh], solver_container[iZone][iMesh], config[iZone], iMesh, Iteration);
         

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -621,6 +621,13 @@ void CMeanFlowIteration::Update(COutput *output,
     
   }
   
+  /*--- Verify convergence criteria (based on total time) ---*/
+
+  if (config_container[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING) {
+    Physical_t = config_container[val_iZone]->GetCurrent_UnstTime();
+    if (Physical_t >=  config_container[val_iZone]->GetTotal_UnstTime())
+      integration_container[val_iZone][FLOW_SOL]->SetConvergence(true);
+  }
 }
 
 void CMeanFlowIteration::Monitor()     { }

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -3871,6 +3871,8 @@ void COutput::SetRestart(CConfig *config, CGeometry *geometry, CSolver **solver,
     restart_file <<"EXT_ITER= " << config->GetExtIter() + 1 << endl;
   else
     restart_file <<"EXT_ITER= " << config->GetExtIter() + config->GetExtIter_OffSet() + 1 << endl;
+  if (config->GetUnsteady_Simulation() == TIME_STEPPING)
+    restart_file << "TOTAL_TIME= " << config->GetCurrent_UnstTime() << endl;
   
   restart_file.close();
   
@@ -4187,7 +4189,8 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
     unsigned long iExtIter = config[val_iZone]->GetExtIter();
     unsigned long ExtIter_OffSet = config[val_iZone]->GetExtIter_OffSet();
     if (config[val_iZone]->GetUnsteady_Simulation() == DT_STEPPING_1ST ||
-        config[val_iZone]->GetUnsteady_Simulation() == DT_STEPPING_2ND)
+        config[val_iZone]->GetUnsteady_Simulation() == DT_STEPPING_2ND ||
+        config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING)
       ExtIter_OffSet = 0;
 
     /*--- WARNING: These buffers have hard-coded lengths. Note that you
@@ -5134,6 +5137,9 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
             
             if (!Unsteady) cout << endl << " Iter" << "    Time(s)";
             else cout << endl << " IntIter" << " ExtIter";
+            if (Unsteady ||
+                config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING)
+              cout << " Unst. Time";
             
             //            if (!fluid_structure) {
             if (incompressible) cout << "   Res[Press]" << "     Res[Velx]" << "   CLift(Total)" << "   CDrag(Total)" << endl;
@@ -5188,6 +5194,9 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
             
             if (!Unsteady) cout << endl << " Iter" << "    Time(s)";
             else cout << endl << " IntIter" << " ExtIter";
+            if (Unsteady ||
+                config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING)
+              cout << " Unst. Time";
             if (incompressible) cout << "   Res[Press]";
             else cout << "      Res[Rho]";//, cout << "     Res[RhoE]";
             
@@ -5347,6 +5356,10 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
           cout.width(8); cout << iIntIter;
           cout.width(8); cout << iExtIter;
         }
+      }
+      if (Unsteady ||
+          config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING) {
+          cout.width(11); cout << config[val_iZone]->GetCurrent_UnstTime();
       }
       
       
@@ -14741,10 +14754,12 @@ void COutput::SetRestart_Parallel(CConfig *config, CGeometry *geometry, CSolver 
     restart_file <<"INITIAL_BCTHRUST= " << config->GetInitial_BCThrust() << endl;
     restart_file <<"DCD_DCL_VALUE= " << config->GetdCD_dCL() << endl;
     if (adjoint) restart_file << "SENS_AOA=" << solver[ADJFLOW_SOL]->GetTotal_Sens_AoA() * PI_NUMBER / 180.0 << endl;
-    if (dual_time)
+    if (dual_time || config->GetUnsteady_Simulation() == TIME_STEPPING)
       restart_file <<"EXT_ITER= " << config->GetExtIter() + 1 << endl;
     else
       restart_file <<"EXT_ITER= " << config->GetExtIter() + config->GetExtIter_OffSet() + 1 << endl;
+    if (config->GetUnsteady_Simulation() == TIME_STEPPING)
+      restart_file << "TOTAL_TIME= " << config->GetCurrent_UnstTime() << endl;
   }
   
   /*--- All processors close the file. ---*/

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -3872,7 +3872,7 @@ void COutput::SetRestart(CConfig *config, CGeometry *geometry, CSolver **solver,
   else
     restart_file <<"EXT_ITER= " << config->GetExtIter() + config->GetExtIter_OffSet() + 1 << endl;
   if (config->GetUnsteady_Simulation() == TIME_STEPPING)
-    restart_file << "TOTAL_TIME= " << 0.01 << endl;
+    restart_file << "TOTAL_TIME= " << config->GetCurrent_UnstTime() << endl;
   
   restart_file.close();
   
@@ -4688,6 +4688,11 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
     if (Unsteady) write_heads = (iIntIter == 0);
     else write_heads = (((iExtIter % (config[val_iZone]->GetWrt_Con_Freq()*40)) == 0));
     
+    /*--- Write the table header if time-stepping simulation is restarting ---*/
+    if (time_stepping && config[val_iZone]->GetRestart())
+      if (config[val_iZone]->GetUnst_RestartIter() == iExtIter)
+        write_heads = true;
+
     bool write_turbo = (((iExtIter % (config[val_iZone]->GetWrt_Con_Freq()*200)) == 0));
     
     /*--- Analogous for dynamic problems (as of now I separate the problems, it may be worthy to do all together later on ---*/

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -4665,6 +4665,7 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
     
     bool Unsteady = ((config[val_iZone]->GetUnsteady_Simulation() == DT_STEPPING_1ST) ||
                      (config[val_iZone]->GetUnsteady_Simulation() == DT_STEPPING_2ND));
+    bool time_stepping = config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING;
     bool In_NoDualTime = (!DualTime_Iteration && (iExtIter % config[val_iZone]->GetWrt_Con_Freq() == 0));
     bool In_DualTime_0 = (DualTime_Iteration && (iIntIter % config[val_iZone]->GetWrt_Con_Freq_DualTime() == 0));
     bool In_DualTime_1 = (!DualTime_Iteration && Unsteady);
@@ -5137,9 +5138,7 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
             
             if (!Unsteady) cout << endl << " Iter" << "    Time(s)";
             else cout << endl << " IntIter" << " ExtIter";
-            if (Unsteady ||
-                config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING)
-              cout << " Unst. Time";
+            if (Unsteady || time_stepping) cout << " Unst. Time";
             
             //            if (!fluid_structure) {
             if (incompressible) cout << "   Res[Press]" << "     Res[Velx]" << "   CLift(Total)" << "   CDrag(Total)" << endl;
@@ -5194,9 +5193,7 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
             
             if (!Unsteady) cout << endl << " Iter" << "    Time(s)";
             else cout << endl << " IntIter" << " ExtIter";
-            if (Unsteady ||
-                config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING)
-              cout << " Unst. Time";
+            if (Unsteady || time_stepping) cout << " Unst. Time";
             if (incompressible) cout << "   Res[Press]";
             else cout << "      Res[Rho]";//, cout << "     Res[RhoE]";
             
@@ -5357,15 +5354,11 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
           cout.width(8); cout << iExtIter;
         }
       }
-      if (Unsteady ||
-          config[val_iZone]->GetUnsteady_Simulation() == TIME_STEPPING) {
-          cout.width(11); cout << config[val_iZone]->GetCurrent_UnstTime();
-      }
       
       
       switch (config[val_iZone]->GetKind_Solver()) {
         case EULER : case NAVIER_STOKES:
-          
+
           if (!DualTime_Iteration) {
             if (compressible) ConvHist_file[0] << begin << direct_coeff << flow_resid;
             if (incompressible) ConvHist_file[0] << begin << direct_coeff << flow_resid;
@@ -5380,6 +5373,10 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
             ConvHist_file[0].flush();
           }
           
+          if ((Unsteady && DualTime_Iteration) || time_stepping) {
+              cout.width(11); cout << config[val_iZone]->GetCurrent_UnstTime();
+          }
+
     if(DualTime_Iteration || !Unsteady) {
           cout.precision(6);
           cout.setf(ios::fixed, ios::floatfield);
@@ -5433,7 +5430,7 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
           break;
           
         case RANS :
-          
+
           if (!DualTime_Iteration) {
             ConvHist_file[0] << begin << direct_coeff << flow_resid << turb_resid;
             if (aeroelastic) ConvHist_file[0] << aeroelastic_coeff;
@@ -5444,6 +5441,10 @@ void COutput::SetConvHistory_Body(ofstream *ConvHist_file,
             if (output_comboObj) ConvHist_file[0] << combo_obj;
             ConvHist_file[0] << end;
             ConvHist_file[0].flush();
+          }
+
+          if ((Unsteady && DualTime_Iteration) || time_stepping) {
+              cout.width(11); cout << config[val_iZone]->GetCurrent_UnstTime();
           }
           
     if(DualTime_Iteration || !Unsteady) {

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -3872,7 +3872,7 @@ void COutput::SetRestart(CConfig *config, CGeometry *geometry, CSolver **solver,
   else
     restart_file <<"EXT_ITER= " << config->GetExtIter() + config->GetExtIter_OffSet() + 1 << endl;
   if (config->GetUnsteady_Simulation() == TIME_STEPPING)
-    restart_file << "TOTAL_TIME= " << config->GetCurrent_UnstTime() << endl;
+    restart_file << "TOTAL_TIME= " << 0.01 << endl;
   
   restart_file.close();
   

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -317,7 +317,7 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
       if (position != string::npos) {
         text_line.erase (0,11);
         config->SetCurrent_UnstTime(atof(text_line.c_str()));
-      } else {
+      } else if (config->GetUnsteady_Simulation() == TIME_STEPPING) {
         config->SetCurrent_UnstTime(0.0);
       }
       
@@ -977,6 +977,9 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
     for (iPoint = 0; iPoint < nPoint; iPoint++)
       node[iPoint] = new CEulerVariable(Density_Inf, Velocity_Inf, Energy_Inf, nDim, nVar, config);
     
+    if (config->GetUnsteady_Simulation() == TIME_STEPPING)
+      config->SetCurrent_UnstTime(0.0);
+
   } else {
         
     /*--- Multizone problems require the number of the zone to be appended. ---*/
@@ -15165,7 +15168,7 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
       if (position != string::npos) {
         text_line.erase (0,11);
         config->SetCurrent_UnstTime(atof(text_line.c_str()));
-      } else {
+      } else if (config->GetUnsteady_Simulation() == TIME_STEPPING) {
         config->SetCurrent_UnstTime(0.0);
       }
 

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -311,8 +311,18 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
           config->SetExtIter_OffSet(ExtIter_);
       }
       
+      /*--- Total time ---*/
+
+      position = text_line.find ("TOTAL_TIME=",0);
+      if (position != string::npos) {
+        text_line.erase (0,11);
+        config->SetCurrent_UnstTime(atof(text_line.c_str()));
+      } else {
+        config->SetCurrent_UnstTime(0.0);
+      }
+      
     }
-    
+
     /*--- Close the restart file... we will open this file again... ---*/
     
     restart_file.close();
@@ -4620,7 +4630,7 @@ void CEulerSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container,
       (config->GetKind_TimeIntScheme_Flow() == RUNGE_KUTTA_LIMEX_SMR91) );
 
   bool grid_movement = config->GetGrid_Movement();
-    bool time_steping = config->GetUnsteady_Simulation() == TIME_STEPPING;
+    bool time_stepping = config->GetUnsteady_Simulation() == TIME_STEPPING;
   bool dual_time = ((config->GetUnsteady_Simulation() == DT_STEPPING_1ST) ||
                     (config->GetUnsteady_Simulation() == DT_STEPPING_2ND));
   
@@ -4744,7 +4754,12 @@ void CEulerSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container,
   
   /*--- For exact time solution use the minimum delta time of the whole mesh ---*/
   
-  if (time_steping) {
+  if (time_stepping) {
+    /*--- If the unsteady CFL is set to zero, it uses the defined unsteady time step, otherwise
+     * it computes the time step based on the unsteady CFL ---*/
+    if (config->GetUnst_CFL() == 0) {
+      Global_Delta_Time = config->GetDelta_UnstTimeND();
+    } else {
 #ifdef HAVE_MPI
     su2double rbuf_time, sbuf_time;
     sbuf_time = Global_Delta_Time;
@@ -4752,19 +4767,10 @@ void CEulerSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container,
     SU2_MPI::Bcast(&rbuf_time, 1, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
     Global_Delta_Time = rbuf_time;
 #endif
-    for (iPoint = 0; iPoint < nPointDomain; iPoint++) {
-            
-            /*--- Sets the regular CFL equal to the unsteady CFL ---*/
-            config->SetCFL(iMesh,config->GetUnst_CFL());
-            
-            /*--- If the unsteady CFL is set to zero, it uses the defined unsteady time step, otherwise
-             it computes the time step based on the unsteady CFL ---*/
-            if (config->GetCFL(iMesh) == 0.0) {
-                node[iPoint]->SetDelta_Time(config->GetDelta_UnstTime());
-            } else {
-                node[iPoint]->SetDelta_Time(Global_Delta_Time);
-            }
-        }
+    }
+    for (iPoint = 0; iPoint < nPointDomain; iPoint++)
+      node[iPoint]->SetDelta_Time(Global_Delta_Time);
+    config->AddCurrent_UnstTime(Global_Delta_Time);
   }
   
   /*--- Recompute the unsteady time step for the dual time strategy
@@ -15153,6 +15159,16 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
           config->SetExtIter_OffSet(ExtIter_);
       }
       
+      /*--- Total time ---*/
+
+      position = text_line.find ("TOTAL_TIME=",0);
+      if (position != string::npos) {
+        text_line.erase (0,11);
+        config->SetCurrent_UnstTime(atof(text_line.c_str()));
+      } else {
+        config->SetCurrent_UnstTime(0.0);
+      }
+
     }
     
     /*--- Close the restart file... we will open this file again... ---*/
@@ -15808,6 +15824,9 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
     for (iPoint = 0; iPoint < nPoint; iPoint++)
       node[iPoint] = new CNSVariable(Density_Inf, Velocity_Inf, Energy_Inf, nDim, nVar, config);
     
+    if (config->GetUnsteady_Simulation() == TIME_STEPPING)
+      config->SetCurrent_UnstTime(0.0);
+
   }
   
   else {
@@ -16404,12 +16423,11 @@ void CNSSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container, CC
   
   /*--- For exact time solution use the minimum delta time of the whole mesh ---*/
   if (config->GetUnsteady_Simulation() == TIME_STEPPING) {
-    int rank = MASTER_NODE;
-#ifdef HAVE_MPI
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-#endif
-
-
+    /*--- If the unsteady CFL is set to zero, it uses the defined unsteady time step, otherwise
+     * it computes the time step based on the unsteady CFL ---*/
+    if (config->GetUnst_CFL() == 0) {
+      Global_Delta_Time = config->GetDelta_UnstTimeND();
+    } else {
 #ifdef HAVE_MPI
     su2double rbuf_time, sbuf_time;
     sbuf_time = Global_Delta_Time;
@@ -16417,19 +16435,10 @@ void CNSSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container, CC
     SU2_MPI::Bcast(&rbuf_time, 1, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
     Global_Delta_Time = rbuf_time;
 #endif
-    for (iPoint = 0; iPoint < nPointDomain; iPoint++) {
-            
-            /*--- Sets the regular CFL equal to the unsteady CFL ---*/
-            config->SetCFL(iMesh,config->GetUnst_CFL());
-            
-            /*--- If the unsteady CFL is set to zero, it uses the defined unsteady time step, otherwise
-             it computes the time step based on the unsteady CFL ---*/
-            if (config->GetCFL(iMesh) == 0.0) {
-                node[iPoint]->SetDelta_Time(config->GetDelta_UnstTime());
-            } else {
-                node[iPoint]->SetDelta_Time(Global_Delta_Time);
-            }
-        }
+    }
+    for (iPoint = 0; iPoint < nPointDomain; iPoint++)
+      node[iPoint]->SetDelta_Time(Global_Delta_Time);
+    config->AddCurrent_UnstTime(Global_Delta_Time);
   }
   
   /*--- Recompute the unsteady time step for the dual time strategy

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -4777,9 +4777,13 @@ void CEulerSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container,
     Global_Delta_Time = rbuf_time;
 #endif
     }
-    /*--- NOTE: If we need the RK substeps to be different times than the
-     * full timestep, then the `Delta_Time` value may need to be adjusted.
-     * This is a single value, representing the time across all substeps. ---*/
+    /*--- XXX: Setting the time once each iteration like this works for the
+     * current case, where the time is only used for tracking (i.e. when
+     * the simulation reaches the max time, it stops).  It will not work if 
+     * the actual time is needed as part of the residual calculation.  If
+     * du/dt = F(u, t), the residual will not be calculated correctly.  This
+     * is especially true for RK schemes, which evaluate the residual at
+     * separate times for the substeps. ---*/
     for (iPoint = 0; iPoint < nPointDomain; iPoint++)
       node[iPoint]->SetDelta_Time(Global_Delta_Time);
     config->AddCurrent_UnstTime(Global_Delta_Time);
@@ -16454,9 +16458,13 @@ void CNSSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container, CC
     Global_Delta_Time = rbuf_time;
 #endif
     }
-    /*--- NOTE: If we need the RK substeps to be different times than the
-     * full timestep, then the `Delta_Time` value may need to be adjusted.
-     * This is a single value, representing the time across all substeps. ---*/
+    /*--- XXX: Setting the time once each iteration like this works for the
+     * current case, where the time is only used for tracking (i.e. when
+     * the simulation reaches the max time, it stops).  It will not work if 
+     * the actual time is needed as part of the residual calculation.  If
+     * du/dt = F(u, t), the residual will not be calculated correctly.  This
+     * is especially true for RK schemes, which evaluate the residual at
+     * separate times for the substeps. ---*/
     for (iPoint = 0; iPoint < nPointDomain; iPoint++)
       node[iPoint]->SetDelta_Time(Global_Delta_Time);
     config->AddCurrent_UnstTime(Global_Delta_Time);

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -220,6 +220,12 @@ CEulerSolver::CEulerSolver(CGeometry *geometry, CConfig *config, unsigned short 
       filename_ = config->GetUnsteady_FileName(filename_, Unst_RestartIter);
     }
 
+    /*--- Ensure that the solver had time=0 if no time is found ---*/
+
+    if (time_stepping) {
+      config->SetCurrent_UnstTime(0.0);
+    }
+
     /*--- Open the restart file, throw an error if this fails. ---*/
     
     restart_file.open(filename_.data(), ios::in);
@@ -15069,6 +15075,12 @@ CNSSolver::CNSSolver(CGeometry *geometry, CConfig *config, unsigned short iMesh)
       if (adjoint) Unst_RestartIter = SU2_TYPE::Int(config->GetUnst_AdjointIter())-1;
       else Unst_RestartIter = SU2_TYPE::Int(config->GetUnst_RestartIter())-1;
       filename_ = config->GetUnsteady_FileName(filename_, Unst_RestartIter);
+    }
+
+    /*--- Ensure that the solver had time=0 if no time is found ---*/
+
+    if (time_stepping) {
+      config->SetCurrent_UnstTime(0.0);
     }
 
     /*--- Open the restart file, throw an error if this fails. ---*/

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -4777,6 +4777,9 @@ void CEulerSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container,
     Global_Delta_Time = rbuf_time;
 #endif
     }
+    /*--- NOTE: If we need the RK substeps to be different times than the
+     * full timestep, then the `Delta_Time` value may need to be adjusted.
+     * This is a single value, representing the time across all substeps. ---*/
     for (iPoint = 0; iPoint < nPointDomain; iPoint++)
       node[iPoint]->SetDelta_Time(Global_Delta_Time);
     config->AddCurrent_UnstTime(Global_Delta_Time);
@@ -16451,6 +16454,9 @@ void CNSSolver::SetTime_Step(CGeometry *geometry, CSolver **solver_container, CC
     Global_Delta_Time = rbuf_time;
 #endif
     }
+    /*--- NOTE: If we need the RK substeps to be different times than the
+     * full timestep, then the `Delta_Time` value may need to be adjusted.
+     * This is a single value, representing the time across all substeps. ---*/
     for (iPoint = 0; iPoint < nPointDomain; iPoint++)
       node[iPoint]->SetDelta_Time(Global_Delta_Time);
     config->AddCurrent_UnstTime(Global_Delta_Time);

--- a/SU2_SOL/src/SU2_SOL.cpp
+++ b/SU2_SOL/src/SU2_SOL.cpp
@@ -282,10 +282,12 @@ int main(int argc, char *argv[]) {
 				if ((iExtIter+1 == config_container[ZONE_0]->GetnExtIter()) ||
 						((iExtIter % config_container[ZONE_0]->GetWrt_Sol_Freq() == 0) && (iExtIter != 0) &&
 								!((config_container[ZONE_0]->GetUnsteady_Simulation() == DT_STEPPING_1ST) ||
-										(config_container[ZONE_0]->GetUnsteady_Simulation() == DT_STEPPING_2ND))) ||
+										(config_container[ZONE_0]->GetUnsteady_Simulation() == DT_STEPPING_2ND) ||
+										(config_container[ZONE_0]->GetUnsteady_Simulation() == TIME_STEPPING))) ||
 										(StopCalc) ||
 										(((config_container[ZONE_0]->GetUnsteady_Simulation() == DT_STEPPING_1ST) ||
-												(config_container[ZONE_0]->GetUnsteady_Simulation() == DT_STEPPING_2ND)) &&
+												(config_container[ZONE_0]->GetUnsteady_Simulation() == DT_STEPPING_2ND) ||
+		                    (config_container[ZONE_0]->GetUnsteady_Simulation() == TIME_STEPPING)) &&
 												((iExtIter == 0) || (iExtIter % config_container[ZONE_0]->GetWrt_Sol_Freq_DualTime() == 0)))) {
 
 					


### PR DESCRIPTION
I've separated out some of the fixes I made to time-stepping while working on the hybrid branch. I implemented the following fixes:

+ The total time is recorded as the simulation progresses
+ The total time is saved to restart files and can be reloaded
+ The total time is displayed as an extra column in unsteady simulations
+ The code will now stop when the final time (`UNST_TIME`) is reached.