### PR TITLE
Add extra turb length/time calculation

### DIFF
--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -4000,6 +4000,9 @@ void CTurbKESolver::Postprocessing(CGeometry *geometry,
     SetSolution_Gradient_LS(geometry, config);
   }
 
+  /*--- Recompute turbulence scales to ensure they're up to date ---*/
+  CalculateTurbScales(solver_container, config);
+
   for (iPoint = 0; iPoint < nPoint; iPoint ++) {
 
     /*--- Compute turbulence scales ---*/
@@ -4033,7 +4036,7 @@ void CTurbKESolver::Postprocessing(CGeometry *geometry,
 void CTurbKESolver::CalculateTurbScales(CSolver **solver_container,
                                         CConfig *config) {
 
-  for (unsigned long iPoint = 0; iPoint < nPointDomain; iPoint++) {
+  for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
     const su2double rho = solver_container[FLOW_SOL]->node[iPoint]->GetDensity();
     const su2double mu = solver_container[FLOW_SOL]->node[iPoint]->GetLaminarViscosity();
 

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -169,7 +169,7 @@ def main():
     turb_flatplate_v2f.cfg_dir   = "rans/flatplate"
     turb_flatplate_v2f.cfg_file  = "turb_v2f_flatplate.cfg"
     turb_flatplate_v2f.test_iter = 400
-    turb_flatplate_v2f.test_vals = [-1.431857, 3.700928, -0.187405, 0.003454] #last 4 columns
+    turb_flatplate_v2f.test_vals = [-1.049704, 4.106786, -0.187459, 0.003495] #last 4 columns
     turb_flatplate_v2f.su2_exec  = "SU2_CFD"
     turb_flatplate_v2f.timeout   = 1600
     turb_flatplate_v2f.tol       = 0.00001


### PR DESCRIPTION
Currently, length and timescales for the v2f method are only calculated
when the source residual is calculated. This leads to problems where the
eddy viscosity is needed but the residual is not.  For example, the eddy
viscosity is calculated when a restart file is loaded, which means that
incorrect values of T and L are used.

This commit adds an extra computation of the turb time and lengthscales,
to ensure that they are properly initialized when the eddy viscosity is
calculated.