### PR TITLE
Pecos output fixes

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -740,6 +740,7 @@ private:
   Wrt_Limiters,              /*!< \brief Write residuals to solution file */
   Wrt_SharpEdges,              /*!< \brief Write residuals to solution file */
   Wrt_Halo,                   /*!< \brief Write rind layers in solution files */
+  Wrt_Resolution_Tensors,     /*!< \brief Write resolutions tensors in solution files */
   Plot_Section_Forces;       /*!< \brief Write sectional forces for specified markers. */
   unsigned short Console_Output_Verb,  /*!< \brief Level of verbosity for console output */
   Kind_Average;        /*!< \brief Particular average for the marker analyze. */
@@ -2912,6 +2913,12 @@ public:
    */
   bool GetWrt_Halo(void);
   
+  /*!
+   * \brief Get information about writing the resolution tensors to the solution files.
+   * \return <code>TRUE</code> means that resolution tensors will be written to the solution file.
+   */
+  bool GetWrt_Resolution_Tensors(void);
+
   /*!
    * \brief Get information about writing sectional force files.
    * \return <code>TRUE</code> means that sectional force files will be written for specified markers.

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -1585,6 +1585,8 @@ inline bool CConfig::GetWrt_SharpEdges(void) { return Wrt_SharpEdges; }
 
 inline bool CConfig::GetWrt_Halo(void) { return Wrt_Halo; }
 
+inline bool CConfig::GetWrt_Resolution_Tensors(void) { return Wrt_Resolution_Tensors; }
+
 inline bool CConfig::GetPlot_Section_Forces(void) { return Plot_Section_Forces; }
 
 inline vector<vector<su2double> > CConfig::GetAeroelastic_np1(unsigned short iMarker) { return Aeroelastic_np1[iMarker]; }

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1532,6 +1532,8 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   addBoolOption("WRT_SHARPEDGES", Wrt_SharpEdges, false);
   /* DESCRIPTION: Output the rind layers in the solution files  \ingroup Config*/
   addBoolOption("WRT_HALO", Wrt_Halo, false);
+  /* DESCRIPTION: Output the resolution tensors in the solution files  \ingroup Config*/
+  addBoolOption("WRT_RESOLUTION_TENSORS", Wrt_Resolution_Tensors, false);
   /*!\brief MARKER_ANALYZE_AVERAGE
    *  \n DESCRIPTION: Output averaged flow values on specified analyze marker.
    *  Options: AREA, MASSFLUX

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -437,6 +437,10 @@ CDriver::CDriver(char* confFile,
 
   output = new COutput(config_container[ZONE_0]);
 
+  /*--- Register variables for output ---*/
+
+  output->RegisterAllVariables(config_container, nZone);
+
   /*--- Open the convergence history file ---*/
 
   if (rank == MASTER_NODE){

--- a/SU2_CFD/src/output_cgns.cpp
+++ b/SU2_CFD/src/output_cgns.cpp
@@ -505,7 +505,25 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
         break;
       }
   }  
+
+  for (std::vector<COutputVariable>::iterator it = output_vars[iZone].begin();
+       it != output_vars[iZone].end(); ++it) {
+    cgns_err = cg_field_write(cgns_file, cgns_base, cgns_zone, cgns_flow, RealDouble, it->Name.c_str(), Data[iVar], &cgns_field); iVar++;
+    if (cgns_err) cg_error_print();
+  }
   
+  for (std::vector<COutputTensor>::iterator it = output_tensors[iZone].begin();
+       it != output_tensors[iZone].end(); ++it) {
+    for (unsigned short iDim = 1; iDim < geometry->GetnDim()+1; iDim++) {
+      for (unsigned short jDim = 1; jDim < geometry->GetnDim()+1; jDim++) {
+        ostringstream label(it->Name);
+        label << "_" << iDim << jDim;
+        cgns_err = cg_field_write(cgns_file, cgns_base, cgns_zone, cgns_flow, RealDouble, label.str().c_str(), Data[iVar], &cgns_field); iVar++;
+        if (cgns_err) cg_error_print();
+      }
+    }
+  }
+
   /*--- Close CGNS file ---*/
   cgns_err = cg_close(cgns_file);
   if (cgns_err) cg_error_print();

--- a/SU2_CFD/src/output_cgns.cpp
+++ b/SU2_CFD/src/output_cgns.cpp
@@ -524,6 +524,18 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
     }
   }
 
+  if ((config->GetKind_HybridRANSLES() == DYNAMIC_HYBRID) &&
+      config->GetWrt_Resolution_Tensors()) {
+    for (unsigned short iDim = 1; iDim < geometry->GetnDim()+1; iDim++) {
+      for (unsigned short jDim = 1; jDim < geometry->GetnDim()+1; jDim++) {
+        ostringstream label("Resolution_Tensor_");
+        label << iDim << jDim;
+        cgns_err = cg_field_write(cgns_file, cgns_base, cgns_zone, cgns_flow, RealDouble, label.str().c_str(), Data[iVar], &cgns_field); iVar++;
+        if (cgns_err) cg_error_print();
+      }
+    }
+  }
+
   /*--- Close CGNS file ---*/
   cgns_err = cg_close(cgns_file);
   if (cgns_err) cg_error_print();

--- a/SU2_CFD/src/output_fieldview.cpp
+++ b/SU2_CFD/src/output_fieldview.cpp
@@ -230,6 +230,20 @@ void COutput::SetFieldViewASCII(CConfig *config, CGeometry *geometry, unsigned s
       FieldView_File << "Eddy_Viscosity" << endl;
     }
     
+    for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+         it != output_vars[val_iZone].end(); ++it) {
+      FieldView_File << it->Name << endl;
+    }
+    
+    for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+         it != output_tensors[val_iZone].end(); ++it) {
+      for (unsigned short iDim = 1; iDim < nDim+1; iDim++) {
+        for (unsigned short jDim = 1; jDim < nDim+1; jDim++) {
+          FieldView_File << it->Name << "_" << iDim << jDim << endl;
+        }
+      }
+    }
+
     if (config->GetWrt_SharpEdges()) {
       if ((Kind_Solver == EULER) || (Kind_Solver == NAVIER_STOKES) || (Kind_Solver == RANS)) {
         FieldView_File << "Sharp_Edge_Dist" << endl;

--- a/SU2_CFD/src/output_fieldview.cpp
+++ b/SU2_CFD/src/output_fieldview.cpp
@@ -244,6 +244,15 @@ void COutput::SetFieldViewASCII(CConfig *config, CGeometry *geometry, unsigned s
       }
     }
 
+    if ((config->GetKind_HybridRANSLES() == DYNAMIC_HYBRID) &&
+        config->GetWrt_Resolution_Tensors()) {
+      for (unsigned short iDim = 1; iDim < nDim+1; iDim++) {
+        for (unsigned short jDim = 1; jDim < nDim+1; jDim++) {
+          FieldView_File << "Resolution_Tensor_" << iDim << jDim << endl;
+        }
+      }
+    }
+
     if (config->GetWrt_SharpEdges()) {
       if ((Kind_Solver == EULER) || (Kind_Solver == NAVIER_STOKES) || (Kind_Solver == RANS)) {
         FieldView_File << "Sharp_Edge_Dist" << endl;

--- a/SU2_CFD/src/output_paraview.cpp
+++ b/SU2_CFD/src/output_paraview.cpp
@@ -750,7 +750,7 @@ void COutput::SetParaview_ASCII(CConfig *config, CGeometry *geometry, unsigned s
       VarCounter += nDim*nDim;
     }
 
-    if (dynamic_hybrid) {
+    if (dynamic_hybrid && config->GetWrt_Resolution_Tensors()) {
       Paraview_File << "\nTENSORS Resolution_Tensor float\n";
 
       for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {

--- a/SU2_CFD/src/output_paraview.cpp
+++ b/SU2_CFD/src/output_paraview.cpp
@@ -708,24 +708,49 @@ void COutput::SetParaview_ASCII(CConfig *config, CGeometry *geometry, unsigned s
       
     }
     
-    if (dynamic_hybrid) {
-      Paraview_File << "\nTENSORS Eddy_Viscosity_Anisotropy float\n";
+    for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+         it != output_vars[val_iZone].end(); ++it) {
+
+      Paraview_File << "\nSCALARS " << it->Name << " float 1\n";
+      Paraview_File << "LOOKUP_TABLE default\n";
+
+      for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
+        if (surf_sol) {
+          if (LocalIndex[iPoint+1] != 0) {
+            /*--- Loop over the vars/residuals and write the values to file ---*/
+            Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+          }
+        } else {
+          /*--- Loop over the vars/residuals and write the values to file ---*/
+          Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+        }
+      }
+      VarCounter++;
+
+    }
+    
+    for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+         it != output_tensors[val_iZone].end(); ++it) {
+      Paraview_File << "\nTENSORS " << it->Name << " float\n";
 
       for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
         if (!surf_sol || LocalIndex[iPoint+1] != 0) {
           /*--- Loop over the vars/residuals and write the values to file ---*/
-          for (int iDim = 0; iDim < 3; iDim++) {
-            for (int jDim = 0; jDim < 3; jDim++) {
+          for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+            for (unsigned short jDim = 0; jDim < nDim; jDim++) {
               Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
               VarCounter++;
             }
             Paraview_File << endl;
           }
           Paraview_File << endl;
-          VarCounter -= 9;
+          VarCounter -= nDim*nDim;
         }
       }
-      VarCounter += 9;
+      VarCounter += nDim*nDim;
+    }
+
+    if (dynamic_hybrid) {
       Paraview_File << "\nTENSORS Resolution_Tensor float\n";
 
       for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
@@ -743,33 +768,6 @@ void COutput::SetParaview_ASCII(CConfig *config, CGeometry *geometry, unsigned s
         }
       }
       VarCounter += 9;
-      switch (config->GetKind_Hybrid_Blending()) {
-        case RANS_ONLY:
-          // No extra variables
-          break;
-        case FULL_TRANSPORT:
-          // Add resolution adequacy.
-          Paraview_File << "\nSCALARS Resolution_Adequacy float 1\n";
-          Paraview_File << "LOOKUP_TABLE default\n";
-          /*--- Loop over the vars/residuals and write the values to file ---*/
-          for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
-            if (!surf_sol || LocalIndex[iPoint+1] != 0) {
-                Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
-            }
-          }
-          VarCounter++;
-          // Add RANS weight
-          Paraview_File << "\nSCALARS RANS_Weight float 1\n";
-          Paraview_File << "LOOKUP_TABLE default\n";
-          /*--- Loop over the vars/residuals and write the values to file ---*/
-          for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
-            if (!surf_sol || LocalIndex[iPoint+1] != 0) {
-                Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
-            }
-          }
-          VarCounter++;
-          break;
-      }
     }
 
     if (( Kind_Solver == ADJ_EULER         ) ||
@@ -1665,6 +1663,47 @@ void COutput::SetParaview_MeshASCII(CConfig *config, CGeometry *geometry, unsign
       
     }
     
+    for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+         it != output_vars[val_iZone].end(); ++it) {
+      
+      Paraview_File << "\nSCALARS " << it->Name << " float 1\n";
+      Paraview_File << "LOOKUP_TABLE default\n";
+      
+      for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
+        if (surf_sol) {
+          if (LocalIndex[iPoint+1] != 0) {
+            /*--- Loop over the vars/residuals and write the values to file ---*/
+            Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+          }
+        } else {
+          /*--- Loop over the vars/residuals and write the values to file ---*/
+          Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+        }
+      }
+      VarCounter++;
+      
+    }
+    
+    for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+         it != output_tensors[val_iZone].end(); ++it) {
+      Paraview_File << "\nTENSORS " << it->Name << " float\n";
+
+      for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
+        if (!surf_sol || LocalIndex[iPoint+1] != 0) {
+          /*--- Loop over the vars/residuals and write the values to file ---*/
+          for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+            for (unsigned short jDim = 0; jDim < nDim; jDim++) {
+              Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+              VarCounter++;
+            }
+            Paraview_File << endl;
+          }
+          Paraview_File << endl;
+          VarCounter -= nDim*nDim;
+        }
+      }
+      VarCounter += nDim*nDim;
+    }
     if (( Kind_Solver == ADJ_EULER         ) ||
         ( Kind_Solver == ADJ_NAVIER_STOKES ) ||
         ( Kind_Solver == ADJ_RANS          )   ) {

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -422,6 +422,71 @@ COutput::~COutput(void) {
   }
 }
 
+/*--- This doesn't really have a good separation of concerns.
+ * The output class shouldn't need to know all the details of the solver.
+ * The individual solvers (flow, RANS, grid movement) should tell the
+ * Output class what to store.  The solvers should be registering the
+ * variables themselves. Then we wouldn't have to check config
+ * to know what to output, and there's less potential for bugs.
+ *
+ * I have kept the variable registration here mostly to keep changes
+ * minimal.
+ */
+void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
+
+  output_vars.resize(val_nZone);
+  output_tensors.resize(val_nZone);
+
+  for (unsigned short iZone = 0; iZone < val_nZone; iZone++) {
+    unsigned short Kind_Solver  = config[iZone]->GetKind_Solver();
+    const bool dynamic_hybrid = (config[iZone]->GetKind_HybridRANSLES() == DYNAMIC_HYBRID);
+  
+    if (dynamic_hybrid) {
+      switch (config[iZone]->GetKind_Hybrid_Blending()) {
+        case RANS_ONLY:
+          // No extra variables
+          break;
+        case FULL_TRANSPORT:
+          RegisterTensor("Eddy_Visc_Anisotropy", "a", FLOW_SOL,
+                          &CVariable::GetEddyViscAnisotropy, iZone);
+          RegisterScalar("Resolution_Adequacy", "r<sub>k</sub>", HYBRID_SOL,
+                           &CVariable::GetResolutionAdequacy, iZone);
+          RegisterScalar("L_m", "L<sub>m</sub>", TURB_SOL,
+                           &CVariable::GetTurbLengthscale, iZone);
+          RegisterScalar("T_m", "T<sub>m</sub>", TURB_SOL,
+                           &CVariable::GetTurbTimescale, iZone);
+          break;
+      }
+    }
+  }
+}
+
+void COutput::RegisterScalar(std::string name, std::string tecplot_name,
+                               unsigned short solver_type,
+                               DataAccessor accessor, unsigned short val_zone) {
+  COutputVariable variable = {name, tecplot_name, solver_type, accessor};
+  output_vars[val_zone].push_back(variable);
+}
+
+void COutput::RegisterTensor(std::string name, std::string tecplot_name,
+                             unsigned short solver_type,
+                             TensorAccessor accessor, unsigned short val_zone) {
+  COutputTensor tensor = {name, tecplot_name, solver_type, accessor};
+  output_tensors[val_zone].push_back(tensor);
+}
+
+su2double COutput::RetrieveVariable(CSolver** solver,
+                                    COutputVariable var,
+                                    unsigned long iPoint) {
+   return CALL_MEMBER_FN(solver[var.Solver_Type]->node[iPoint], var.Accessor)();
+}
+
+su2double COutput::RetrieveTensorComponent(CSolver** solver, COutputTensor var,
+                                  unsigned long iPoint, unsigned short iDim,
+                                  unsigned short jDim) {
+  return CALL_MEMBER_FN(solver[var.Solver_Type]->node[iPoint], var.Accessor)()[iDim][jDim];
+}
+
 void COutput::SetSurfaceCSV_Flow(CConfig *config, CGeometry *geometry,
                                  CSolver *FlowSolver, unsigned long iExtIter,
                                  unsigned short val_iZone) {
@@ -2262,12 +2327,13 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
   
   unsigned short Kind_Solver  = config->GetKind_Solver();
   unsigned short iVar = 0, jVar = 0, FirstIndex = NONE, SecondIndex = NONE, ThirdIndex = NONE;
+  unsigned short iVar_Additional;
   unsigned short nVar_First = 0, nVar_Second = 0, nVar_Third = 0;
   unsigned short iVar_GridVel = 0, iVar_PressCp = 0, iVar_Lam = 0, iVar_MachMean = 0,
   iVar_ViscCoeffs = 0, iVar_HeatCoeffs = 0, iVar_Sens = 0, iVar_Extra = 0, iVar_Eddy = 0, iVar_Sharp = 0,
   iVar_FEA_Vel = 0, iVar_FEA_Accel = 0, iVar_FEA_Stress = 0, iVar_FEA_Stress_3D = 0,
-  iVar_FEA_Extra = 0, iVar_SensDim = 0, iVar_Eddy_Anisotropy = 0,
-  iVar_Resolution_Tensor = 0, iVar_Extra_Hybrid_Vars = 0;
+  iVar_FEA_Extra = 0, iVar_SensDim = 0,
+  iVar_Resolution_Tensor = 0;
   unsigned long iPoint = 0, jPoint = 0, iVertex = 0, iMarker = 0;
   su2double Gas_Constant, Mach2Vel, Mach_Motion, RefDensity, RefPressure = 0.0, factor = 0.0;
   
@@ -2392,25 +2458,24 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
     if (Kind_Solver == RANS) {
       iVar_Eddy = nVar_Total; nVar_Total += 1;
     }
+
+    /*--- Add registered variables to the restart file ---*/
     
-    /*--- Add extra hybrid variables to the output ---*/
+    iVar_Additional = nVar_Total;
+    for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+         it != output_vars[val_iZone].end(); ++it) {
+      nVar_Total += 1;
+    }
+    
+    for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+         it != output_tensors[val_iZone].end(); ++it) {
+      nVar_Total += nDim*nDim;
+    }
+
 
     if (dynamic_hybrid) {
-      // Add the eddy viscosity anisotropy (a rank 3 tensor)
-      iVar_Eddy_Anisotropy = nVar_Total; nVar_Total += 9;
       // Add the resolution tensors (a rank 3 tensor)
       iVar_Resolution_Tensor = nVar_Total; nVar_Total += 9;
-      switch (config->GetKind_Hybrid_Blending()) {
-        case RANS_ONLY:
-          // No extra variables
-          break;
-        case FULL_TRANSPORT:
-          // Add resolution adequacy, RANS weight, length, and timescales
-          iVar_Extra_Hybrid_Vars = nVar_Total; nVar_Total += 4;
-          break;
-        default:
-          cout << "WARNING: Could not find appropriate output for the hybrid model." << endl;
-      }
     }
 
     /*--- Add Sharp edges to the restart file ---*/
@@ -3158,10 +3223,63 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
       
     }
     
-    /*--- Communicate the Eddy Viscosity Anisotropy ---*/
+    /*--- Communicate the extra scalar variables ---*/
 
-    if (dynamic_hybrid) {
-      iVar = iVar_Eddy_Anisotropy;
+    iVar = iVar_Additional;
+    
+    for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+         it != output_vars[val_iZone].end(); ++it) {
+      /*--- Loop over this partition to collect the current variable ---*/
+
+      jPoint = 0;
+      for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
+
+        /*--- Check for halos & write only if requested ---*/
+
+        if (!Local_Halo[iPoint] || Wrt_Halo) {
+
+          /*--- Load buffers with the extra variables. ---*/
+          Buffer_Send_Var[jPoint] = RetrieveVariable(solver, *it, iPoint);
+
+          jPoint++;
+        }
+      }
+
+      /*--- Gather the data on the master node. ---*/
+
+#ifdef HAVE_MPI
+      SU2_MPI::Gather(Buffer_Send_Var, nBuffer_Scalar, MPI_DOUBLE, Buffer_Recv_Var, nBuffer_Scalar, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
+#else
+      for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++) Buffer_Recv_Var[iPoint] = Buffer_Send_Var[iPoint];
+#endif
+
+      /*--- The master node unpacks and sorts this variable by global index ---*/
+
+      if (rank == MASTER_NODE) {
+        jPoint = 0;
+        for (iProcessor = 0; iProcessor < size; iProcessor++) {
+          for (iPoint = 0; iPoint < Buffer_Recv_nPoint[iProcessor]; iPoint++) {
+
+            /*--- Get global index, then loop over each variable and store ---*/
+
+            iGlobal_Index = Buffer_Recv_GlobalIndex[jPoint];
+            Data[iVar][iGlobal_Index] = Buffer_Recv_Var[jPoint];
+            jPoint++;
+          }
+
+          /*--- Adjust jPoint to index of next proc's data in the buffers. ---*/
+
+          jPoint = (iProcessor+1)*nBuffer_Scalar;
+        }
+      }
+
+      iVar++;
+    }
+
+    /*--- Communicate the extra tensor variables ---*/
+
+    for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+         it != output_tensors[val_iZone].end(); ++it) {
       for (iDim = 0; iDim < nDim; iDim++) {
         for (jDim = 0; jDim < nDim; jDim++) {
 
@@ -3176,7 +3294,7 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
 
               /*--- Load buffers with the variables. ---*/
 
-              Buffer_Send_Var[jPoint] = solver[FLOW_SOL]->node[iPoint]->GetEddyViscAnisotropy(iDim, jDim);
+              Buffer_Send_Var[jPoint] = RetrieveTensorComponent(solver, *it, iPoint, iDim, jDim);
 
               jPoint++;
             }
@@ -3184,11 +3302,11 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
 
           /*--- Gather the data on the master node. ---*/
 
-    #ifdef HAVE_MPI
+#ifdef HAVE_MPI
           SU2_MPI::Gather(Buffer_Send_Var, nBuffer_Scalar, MPI_DOUBLE, Buffer_Recv_Var, nBuffer_Scalar, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
-    #else
+#else
           for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++) Buffer_Recv_Var[iPoint] = Buffer_Send_Var[iPoint];
-    #endif
+#endif
 
           /*--- The master node unpacks and sorts this variable by global index ---*/
 
@@ -3270,113 +3388,6 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
       }
     }
 
-    /*--- Communicate the Extra Variables for Hybrid RANS/LES ---*/
-    // This will need to be changed if more variables are needed.
-    if (dynamic_hybrid && (config->GetKind_Hybrid_Blending() == FULL_TRANSPORT)) {
-
-      /*--- Loop over this partition to collect the current variable ---*/
-      
-      jPoint = 0;
-      for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
-        
-        /*--- Check for halos & write only if requested ---*/
-        
-        if (!Local_Halo[iPoint] || Wrt_Halo) {
-
-          /*--- Load buffers with the extra hybrid variables. ---*/
-
-          Buffer_Send_Var[jPoint] = solver[HYBRID_SOL]->node[iPoint]->GetResolutionAdequacy();
-          Buffer_Send_Res[jPoint] = solver[HYBRID_SOL]->node[iPoint]->GetRANSWeight();
-
-          jPoint++;
-        }
-      }
-      
-      /*--- Gather the data on the master node. ---*/
-      
-#ifdef HAVE_MPI
-      SU2_MPI::Gather(Buffer_Send_Var, nBuffer_Scalar, MPI_DOUBLE, Buffer_Recv_Var, nBuffer_Scalar, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
-      SU2_MPI::Gather(Buffer_Send_Res, nBuffer_Scalar, MPI_DOUBLE, Buffer_Recv_Res, nBuffer_Scalar, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
-#else
-      for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++)
-        Buffer_Recv_Var[iPoint] = Buffer_Send_Var[iPoint];
-      for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++)
-        Buffer_Recv_Res[iPoint] = Buffer_Send_Res[iPoint];
-#endif
-      
-      /*--- The master node unpacks and sorts this variable by global index ---*/
-      
-      if (rank == MASTER_NODE) {
-        jPoint = 0; iVar = iVar_Extra_Hybrid_Vars;
-        for (iProcessor = 0; iProcessor < size; iProcessor++) {
-          for (iPoint = 0; iPoint < Buffer_Recv_nPoint[iProcessor]; iPoint++) {
-            
-            /*--- Get global index, then loop over each variable and store ---*/
-            
-            iGlobal_Index = Buffer_Recv_GlobalIndex[jPoint];
-            Data[iVar + 0][iGlobal_Index] = Buffer_Recv_Var[jPoint];
-            Data[iVar + 1][iGlobal_Index] = Buffer_Recv_Res[jPoint];
-            jPoint++;
-          }
-
-          /*--- Adjust jPoint to index of next proc's data in the buffers. ---*/
-
-          jPoint = (iProcessor+1)*nBuffer_Scalar;
-        }
-      }
-
-      /*--- Loop over this partition to collect the current variable ---*/
-
-      jPoint = 0;
-      for (iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
-
-        /*--- Check for halos & write only if requested ---*/
-
-        if (!Local_Halo[iPoint] || Wrt_Halo) {
-
-          /*--- Load buffers with the extra hybrid variables. ---*/
-
-          Buffer_Send_Var[jPoint] = solver[TURB_SOL]->node[iPoint]->GetTurbLengthscale();
-          Buffer_Send_Res[jPoint] = solver[TURB_SOL]->node[iPoint]->GetTurbTimescale();
-
-          jPoint++;
-        }
-      }
-
-    /*--- Gather the data on the master node. ---*/
-
-#ifdef HAVE_MPI
-    SU2_MPI::Gather(Buffer_Send_Var, nBuffer_Scalar, MPI_DOUBLE, Buffer_Recv_Var, nBuffer_Scalar, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
-    SU2_MPI::Gather(Buffer_Send_Res, nBuffer_Scalar, MPI_DOUBLE, Buffer_Recv_Res, nBuffer_Scalar, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
-#else
-    for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++)
-      Buffer_Recv_Var[iPoint] = Buffer_Send_Var[iPoint];
-    for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++)
-      Buffer_Recv_Res[iPoint] = Buffer_Send_Res[iPoint];
-#endif
-
-    /*--- The master node unpacks and sorts this variable by global index ---*/
-
-    if (rank == MASTER_NODE) {
-      jPoint = 0; iVar = iVar_Extra_Hybrid_Vars+2;
-      for (iProcessor = 0; iProcessor < size; iProcessor++) {
-        for (iPoint = 0; iPoint < Buffer_Recv_nPoint[iProcessor]; iPoint++) {
-
-          /*--- Get global index, then loop over each variable and store ---*/
-
-          iGlobal_Index = Buffer_Recv_GlobalIndex[jPoint];
-          Data[iVar + 0][iGlobal_Index] = Buffer_Recv_Var[jPoint];
-          Data[iVar + 1][iGlobal_Index] = Buffer_Recv_Res[jPoint];
-          jPoint++;
-        }
-
-        /*--- Adjust jPoint to index of next proc's data in the buffers. ---*/
-
-        jPoint = (iProcessor+1)*nBuffer_Scalar;
-      }
-    }
-
-  }
 
     /*--- Communicate the Sharp Edges ---*/
     
@@ -4355,28 +4366,33 @@ void COutput::SetRestart(CConfig *config, CGeometry *geometry, CSolver **solver,
         restart_file << "\t\"<greek>m</greek><sub>t</sub>\"";
     }
     
-    if (dynamic_hybrid) {
+    for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+         it != output_vars[val_iZone].end(); ++it) {
+      if (config->GetOutput_FileFormat() == PARAVIEW)
+        restart_file << "\t\"" << it->Name << "\"";
+      else
+        restart_file << "\t\"" << it->Tecplot_Name << "\"";
+    }
+    
+    for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+         it != output_tensors[val_iZone].end(); ++it) {
       if (config->GetOutput_FileFormat() == PARAVIEW) {
-        restart_file << "\t\"Eddy_Visc_Anisotropy_11\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_12\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_13\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_21\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_22\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_23\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_31\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_32\"";
-        restart_file << "\t\"Eddy_Visc_Anisotropy_33\"";
+        for (unsigned short iDim = 1; iDim < nDim+1; iDim++) {
+          for (unsigned short jDim = 1; jDim < nDim+1; jDim++) {
+            restart_file << "\t\"" << it->Name << "_" << iDim << jDim << "\"";
+          }
+        }
       } else {
-        restart_file << "\t\"a<sub>11</sub>\"";
-        restart_file << "\t\"a<sub>12</sub>\"";
-        restart_file << "\t\"a<sub>13</sub>\"";
-        restart_file << "\t\"a<sub>21</sub>\"";
-        restart_file << "\t\"a<sub>22</sub>\"";
-        restart_file << "\t\"a<sub>23</sub>\"";
-        restart_file << "\t\"a<sub>31</sub>\"";
-        restart_file << "\t\"a<sub>32</sub>\"";
-        restart_file << "\t\"a<sub>33</sub>\"";
+        for (unsigned short iDim = 1; iDim < nDim+1; iDim++) {
+          for (unsigned short jDim = 1; jDim < nDim+1; jDim++) {
+            restart_file << "\t\"" << it->Tecplot_Name;
+            restart_file << "<sub>" << iDim << jDim << "</sub>" << "\"";
+          }
+        }
       }
+    }
+
+    if (dynamic_hybrid) {
       if (config->GetOutput_FileFormat() == PARAVIEW) {
         restart_file << "\t\"Resolution_Tensor_11\"";
         restart_file << "\t\"Resolution_Tensor_12\"";
@@ -4398,28 +4414,7 @@ void COutput::SetRestart(CConfig *config, CGeometry *geometry, CSolver **solver,
         restart_file << "\t\"M<sub>32</sub>\"";
         restart_file << "\t\"M<sub>33</sub>\"";
       }
-      switch (config->GetKind_Hybrid_Blending()) {
-        case RANS_ONLY:
-          // No extra variables
-          break;
-        case FULL_TRANSPORT:
-          // Add length/timescales
-          if (config->GetOutput_FileFormat() == PARAVIEW) {
-            restart_file << "\t\"Resolution_Adequacy\"";
-            restart_file << "\t\"RANS_Weight\"";
-            restart_file << "\t\"Turb_Length\"";
-            restart_file << "\t\"Turb_Time\"";
-          } else {
-            restart_file << "\t\"r<sub>k</sub>\"";
-            restart_file << "\t\"w<sub>rans</sub>\"";
-            restart_file << "\t\"L<sub>m</sub>\"";
-            restart_file << "\t\"T<sub>m</sub>\"";
-          } break;
-        default:
-          cout << "WARNING: Could not find appropriate output for the dynamic_hybrid model." << endl;
-      }
     }
-
 
     if (config->GetWrt_SharpEdges()) {
       if ((Kind_Solver == EULER) || (Kind_Solver == NAVIER_STOKES) || (Kind_Solver == RANS)) {
@@ -12565,17 +12560,28 @@ void COutput::LoadLocalData_Flow(CConfig *config, CGeometry *geometry, CSolver *
 			}
     }
 
+    /*--- Add extra variables ---*/
+
+    for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+         it != output_vars[val_iZone].end(); ++it) {
+      nVar_Par += 1;
+      Variable_Names.push_back(it->Name);
+    }
+
+    for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+         it != output_tensors[val_iZone].end(); ++it) {
+      for (unsigned int iDim=1; iDim < nDim+1; iDim++) {
+        for (unsigned int jDim=1; jDim < nDim+1; jDim++) {
+          nVar_Par += 1;
+          ostringstream label(it->Name);
+          label << "_" << iDim << jDim;
+          Variable_Names.push_back(label.str());
+        }
+      }
+    }
+
     if (dynamic_hybrid) {
-      nVar_Par += 18;
-      Variable_Names.push_back("Eddy_Visc_Aniso_11");
-      Variable_Names.push_back("Eddy_Visc_Aniso_12");
-      Variable_Names.push_back("Eddy_Visc_Aniso_13");
-      Variable_Names.push_back("Eddy_Visc_Aniso_21");
-      Variable_Names.push_back("Eddy_Visc_Aniso_22");
-      Variable_Names.push_back("Eddy_Visc_Aniso_23");
-      Variable_Names.push_back("Eddy_Visc_Aniso_31");
-      Variable_Names.push_back("Eddy_Visc_Aniso_32");
-      Variable_Names.push_back("Eddy_Visc_Aniso_33");
+      nVar_Par += 9;
       Variable_Names.push_back("Resolution_Tensor_11");
       Variable_Names.push_back("Resolution_Tensor_12");
       Variable_Names.push_back("Resolution_Tensor_13");
@@ -12585,18 +12591,6 @@ void COutput::LoadLocalData_Flow(CConfig *config, CGeometry *geometry, CSolver *
       Variable_Names.push_back("Resolution_Tensor_31");
       Variable_Names.push_back("Resolution_Tensor_32");
       Variable_Names.push_back("Resolution_Tensor_33");
-      switch (config->GetKind_Hybrid_Blending()) {
-        case RANS_ONLY:
-          // No extra variables
-          break;
-        case FULL_TRANSPORT:
-          // Add resolution adequacy.
-          Variable_Names.push_back("Resolution_Adequacy"); nVar_Par++;
-          Variable_Names.push_back("RANS_Weight"); nVar_Par++;
-          Variable_Names.push_back("Turb_Lengthscale"); nVar_Par++;
-          Variable_Names.push_back("Turb_Timescale"); nVar_Par++;
-          break;
-      }
     }
 
     /*--- Add the distance to the nearest sharp edge if requested. ---*/
@@ -12867,16 +12861,28 @@ void COutput::LoadLocalData_Flow(CConfig *config, CGeometry *geometry, CSolver *
           Local_Data[jPoint][iVar] = solver[FLOW_SOL]->node[iPoint]->GetEddyViscosity(); iVar++;
         }
         
-        /*--- Load data for a dynamic_hybrid RANS/LES model. ---*/
-        if (dynamic_hybrid) {
-          // Add eddy viscosity anisotropy
-          su2double** eddy_visc_anisotropy = solver[FLOW_SOL]->node[iPoint]->GetEddyViscAnisotropy();
-          for (iDim = 0; iDim < nDim; iDim++) {
-            for (jDim = 0; jDim < nDim; jDim++) {
-              Local_Data[jPoint][iVar] = eddy_visc_anisotropy[iDim][jDim];
+        /*--- Load data for the additional variables ---*/
+
+        for (std::vector<COutputVariable>::iterator it = output_vars[val_iZone].begin();
+             it != output_vars[val_iZone].end(); ++it) {
+          Local_Data[jPoint][iVar] = RetrieveVariable(solver, *it, iPoint);
+          iVar++;
+        }
+        
+        /*--- Load data for the additional tensors ---*/
+
+        for (std::vector<COutputTensor>::iterator it = output_tensors[val_iZone].begin();
+             it != output_tensors[val_iZone].end(); ++it) {
+          for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+            for (unsigned short jDim = 0; jDim < nDim; jDim++) {
+              Local_Data[jPoint][iVar] = RetrieveTensorComponent(solver, *it, iPoint, iDim, jDim);
               iVar++;
             }
           }
+        }
+
+        /*--- Load data for a hybrid RANS/LES model. ---*/
+        if (dynamic_hybrid) {
           // Add the resolution tensor
           su2double** resolution_tensor = geometry->node[iPoint]->GetResolutionTensor();
           for (iDim = 0; iDim < nDim; iDim++) {
@@ -12884,23 +12890,6 @@ void COutput::LoadLocalData_Flow(CConfig *config, CGeometry *geometry, CSolver *
               Local_Data[jPoint][iVar] = resolution_tensor[iDim][jDim];
               iVar++;
             }
-          }
-          switch (config->GetKind_Hybrid_Blending()) {
-            case RANS_ONLY:
-              // No extra variables
-              break;
-            case FULL_TRANSPORT:
-              // Add resolution adequacy and RANS weight
-              Local_Data[jPoint][iVar] = solver[HYBRID_SOL]->node[iPoint]->GetResolutionAdequacy();
-              iVar++;
-              Local_Data[jPoint][iVar] = solver[HYBRID_SOL]->node[iPoint]->GetRANSWeight();
-              iVar++;
-              // Add turbulent length/timescales
-              Local_Data[jPoint][iVar] = solver[TURB_SOL]->node[iPoint]->GetTurbLengthscale();
-              iVar++;
-              Local_Data[jPoint][iVar] = solver[TURB_SOL]->node[iPoint]->GetTurbTimescale();
-              iVar++;
-              break;
           }
         }
 


### PR DESCRIPTION
This is a refactoring of the output to enable a simpler addition of new output variables.  Previously, adding an output variable required changing seven (7!) different sections of code.  Now you can add a new solver output scalar by simply adding a command like the following to `RegisterAllVariables`:

      if (config[iZone]->GetKind_Turb_Model() == KE) {
        RegisterScalar("L_m", "L<sub>m</sub>", TURB_SOL,
                                 &CVariable::GetTurbLengthscale, iZone);
      }

There are a number of shortcomings that I would hope to eventually address, but can be pushed off till a later date (or even indefinitely):

+ The variables must come from a solver variable (CVariable) not a geometry node.  So resolution tensors have to be treated separately.
+ The use of structs and named function pointer types is awkward.  I would love to do an object-oriented solution, but without using C++11, I don't know of a straightforward way to do this.
+ Ideally, the solvers themselves should register variables with the output classes.  The `COutput` class shouldn't have to know what the solver classes are doing. 