### PR TITLE
Add runtime averaging to SU2

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -997,6 +997,9 @@ private:
   su2double *Body_Force_Vector;  /*!< \brief Values of the prescribed body force vector. */
   su2double *FreeStreamTurboNormal; /*!< \brief Direction to initialize the flow in turbomachinery computation */
   ofstream *ConvHistFile;       /*!< \brief Store the pointer to each history file */
+  unsigned short Kind_Averaging;  /*!< \brief Type of runtime-averaging to be performed. */
+  unsigned short Kind_Averaging_Period;  /*!< \brief Type of period over which runtime averages are to be computed. */
+  su2double nAveragingPeriods;  /*!< \brief Number of periods over which to average. */
 
   /*--- all_options is a map containing all of the options. This is used during config file parsing
    to track the options which have not been set (so the default values can be used). Without this map
@@ -8137,6 +8140,12 @@ public:
    * \brief Set the ofstream of the history file for the current zone.
    */
   void SetHistFile(ofstream *HistFile);
+
+  unsigned short GetKind_Averaging(void) const;
+
+  unsigned short GetKind_Averaging_Period(void) const;
+
+  su2double GetnAveragingPeriods(void) const;
 };
 
 #include "config_structure.inl"

--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -8141,10 +8141,22 @@ public:
    */
   void SetHistFile(ofstream *HistFile);
 
+  /*!
+   * \brief Get the type of runtime averaging to be performed (or no averaging)
+   * \return The type of averaging to be performed
+   */
   unsigned short GetKind_Averaging(void) const;
 
+  /*!
+   * \brief Get the type of time interval used as an averaging period.
+   * \return The type of time interval to be performed.
+   */
   unsigned short GetKind_Averaging_Period(void) const;
 
+  /*!
+   * \brief The number of time periods over which to average.
+   * \return The number of time periods over which to average.
+   */
   su2double GetnAveragingPeriods(void) const;
 };
 

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -1835,3 +1835,9 @@ inline bool CConfig::GetQCR(void) {return QCR;}
 inline ofstream* CConfig::GetHistFile(void) { return ConvHistFile; }
 
 inline void CConfig::SetHistFile(ofstream *HistFile) { ConvHistFile = HistFile; }
+
+inline unsigned short CConfig::GetKind_Averaging(void) const { return Kind_Averaging; }
+
+inline unsigned short CConfig::GetKind_Averaging_Period(void) const { return Kind_Averaging_Period; }
+
+inline su2double CConfig::GetnAveragingPeriods(void) const { return nAveragingPeriods; }

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -1803,6 +1803,28 @@ static const map<string, ENUM_INPUT_REF> Input_Ref_Map = CCreateMap<string, ENUM
 ("SU2", SU2_REF)
 ("CUSTOM", CUSTOM_REF);
 
+/*!
+ * \brief Type of runtime averaging to be used.
+ */
+enum ENUM_RUNTIME_AVERAGING {
+  NO_AVERAGING,      /*!< \brief No averaging will be performed (default). */
+  POINTWISE_AVERAGE  /*!< \brief The average will be computed at each point. */
+};
+static const map<string, ENUM_RUNTIME_AVERAGING> RuntimeAverage_Map = CCreateMap<string, ENUM_RUNTIME_AVERAGING>
+("NONE", NO_AVERAGING)
+("POINTWISE", POINTWISE_AVERAGE);
+
+/*!
+ * \brief Time period over which to average.
+ */
+enum ENUM_AVERAGING_PERIOD {
+  TURB_TIMESCALE,   /*!< \brief The local turbulent timescale */
+  FLOW_TIMESCALE    /*!< \brief The freestream flow timescale (L_ref/U_inf) */
+};
+static const map<string, ENUM_AVERAGING_PERIOD> AveragingPeriod_Map = CCreateMap<string, ENUM_AVERAGING_PERIOD>
+("TURB_TIMESCALE", TURB_TIMESCALE)
+("FLOW_TIMESCALE", FLOW_TIMESCALE);
+
 /* END_CONFIG_ENUMS */
 
 class COptionBase {

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -1818,11 +1818,13 @@ static const map<string, ENUM_RUNTIME_AVERAGING> RuntimeAverage_Map = CCreateMap
  * \brief Time period over which to average.
  */
 enum ENUM_AVERAGING_PERIOD {
-  TURB_TIMESCALE,   /*!< \brief The local turbulent timescale */
-  FLOW_TIMESCALE    /*!< \brief The freestream flow timescale (L_ref/U_inf) */
+  TURB_TIMESCALE,     /*!< \brief The local turbulent timescale */
+  MAX_TURB_TIMESCALE, /*!< \brief The maximum turbulent timescale for a flow. */
+  FLOW_TIMESCALE      /*!< \brief The freestream flow timescale (L_ref/U_inf) */
 };
 static const map<string, ENUM_AVERAGING_PERIOD> AveragingPeriod_Map = CCreateMap<string, ENUM_AVERAGING_PERIOD>
 ("TURB_TIMESCALE", TURB_TIMESCALE)
+("MAX_TURB_TIMESCALE", MAX_TURB_TIMESCALE)
 ("FLOW_TIMESCALE", FLOW_TIMESCALE);
 
 /* END_CONFIG_ENUMS */

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -3733,10 +3733,11 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
       }
     }
     if (not(supported)) {
-      SU2_MPI::Error("Your choice of solver does not support averaging!", CURRENT_FUNCTION);
+      SU2_MPI::Error("Your problem definition is not compatible with averaging!", CURRENT_FUNCTION);
     }
 
-    if (Kind_Averaging_Period == TURB_TIMESCALE) {
+    if (Kind_Averaging_Period == TURB_TIMESCALE ||
+        Kind_Averaging_Period == MAX_TURB_TIMESCALE) {
       if (Kind_Solver != RANS && Kind_Solver != ADJ_RANS &&
           Kind_Solver != DISC_ADJ_RANS) {
         SU2_MPI::Error("You must use a RANS model to average over turbulent timescales.", CURRENT_FUNCTION);
@@ -5982,20 +5983,15 @@ void CConfig::SetOutput(unsigned short val_software, unsigned short val_izone) {
 
     cout << "Type of averaging: ";
     switch (Kind_Averaging) {
-      case POINTWISE_AVERAGE:
-        cout << "Pointwise";
-        break;
+      case POINTWISE_AVERAGE: cout << "Pointwise"; break;
     }
     cout << endl;
 
     cout << "Averaging period defined using: ";
     switch (Kind_Averaging_Period) {
-      case TURB_TIMESCALE:
-        cout << "Turbulent timescale";
-        break;
-      case FLOW_TIMESCALE:
-        cout << "Flow timescale";
-        break;
+      case TURB_TIMESCALE: cout << "Turbulent timescale"; break;
+      case MAX_TURB_TIMESCALE: cout << "Maximum turbulent timescale"; break;
+      case FLOW_TIMESCALE: cout << "Freestream flow timescale"; break;
     }
     cout << endl;
 

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -3717,6 +3717,10 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
 
   if (Kind_Averaging != NO_AVERAGING) {
 
+    if (Unsteady_Simulation == STEADY) {
+      SU2_MPI::Error("Runtime averaging cannot be used with a steady-state problem.", CURRENT_FUNCTION);
+    }
+
     /*--- Check that a flow solver is being used ---*/
 
     const unsigned short supported_solvers[] =

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -2129,6 +2129,15 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   /* DESCRIPTION: Multipoint design freestream pressure */
   addPythonOption("MULTIPOINT_FREESTREAM_PRESSURE");
   
+  /*!\brief RUNTIME_AVERAGING \n DESCRIPTION: If averaging is to be performed at runtime, this specifies the type of averaging to be performed.  \n DEFAULT: NO_AVERAGING \ingroup Config */
+  addEnumOption("RUNTIME_AVERAGING", Kind_Averaging, RuntimeAverage_Map, NO_AVERAGING);
+
+  /*!\brief AVERAGING_PERIOD \n DESCRIPTION: If averaging is to be performed at runtime, this specifies the time period over which the averaging will be applied.  \n DEFAULT: TURB_TIMESCALE \ingroup Config */
+  addEnumOption("AVERAGING_PERIOD", Kind_Averaging_Period, AveragingPeriod_Map, TURB_TIMESCALE);
+
+  /*!\brief NUM_AVERAGING_PERIODS \n DESCRIPTION: If averaging is to be performed at runtime, this is the number of time periods over which to average. The inverse of this number can also be thought of as a proportional gain or a relaxation factor for the average calculations.  \n DEFAULT: 4.0 \ingroup Config */
+  addDoubleOption("NUM_AVERAGING_PERIODS", nAveragingPeriods, 4.0);
+
   /* END_CONFIG_OPTIONS */
 
 }

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -3713,6 +3713,43 @@ void CConfig::SetPostprocessing(unsigned short val_software, unsigned short val_
     Design_Variable[0] = NO_DEFORMATION;
   }
 
+  /*--- Check to make sure averaging options are appropriate ---*/
+
+  if (Kind_Averaging != NO_AVERAGING) {
+
+    /*--- Check that a flow solver is being used ---*/
+
+    const unsigned short supported_solvers[] =
+        {EULER, ADJ_EULER, DISC_ADJ_EULER,
+         NAVIER_STOKES, ADJ_NAVIER_STOKES, DISC_ADJ_NAVIER_STOKES,
+         RANS, ADJ_RANS, DISC_ADJ_RANS};
+    const unsigned short nSolvers =
+        sizeof(supported_solvers)/sizeof(supported_solvers[0]);
+    bool supported = false;
+    for (unsigned short iSolver=0; iSolver < nSolvers; iSolver++) {
+      if (Kind_Solver == supported_solvers[iSolver]) {
+        supported = true;
+        break;
+      }
+    }
+    if (not(supported)) {
+      SU2_MPI::Error("Your choice of solver does not support averaging!", CURRENT_FUNCTION);
+    }
+
+    if (Kind_Averaging_Period == TURB_TIMESCALE) {
+      if (Kind_Solver != RANS && Kind_Solver != ADJ_RANS &&
+          Kind_Solver != DISC_ADJ_RANS) {
+        SU2_MPI::Error("You must use a RANS model to average over turbulent timescales.", CURRENT_FUNCTION);
+      }
+      if (not((Kind_Turb_Model == KE) || (Kind_Turb_Model == SST))) {
+        SU2_MPI::Error("Only KE and SST models currently support the use of a turbulent timescale.", CURRENT_FUNCTION);
+      }
+    }
+
+    if (nAveragingPeriods <= 0) {
+      SU2_MPI::Error("The number of averaging periods must be greater than zero.", CURRENT_FUNCTION);
+    }
+  }
 }
 
 void CConfig::SetMarkers(unsigned short val_software) {
@@ -5939,6 +5976,32 @@ void CConfig::SetOutput(unsigned short val_software, unsigned short val_izone) {
       else cout <<"."<< endl;
     }
   }
+
+  if (val_software == SU2_CFD && Kind_Averaging != NO_AVERAGING) {
+    cout << endl <<"--------------------- Runtime Averaging Parameters ----------------------" << endl;
+
+    cout << "Type of averaging: ";
+    switch (Kind_Averaging) {
+      case POINTWISE_AVERAGE:
+        cout << "Pointwise";
+        break;
+    }
+    cout << endl;
+
+    cout << "Averaging period defined using: ";
+    switch (Kind_Averaging_Period) {
+      case TURB_TIMESCALE:
+        cout << "Turbulent timescale";
+        break;
+      case FLOW_TIMESCALE:
+        cout << "Flow timescale";
+        break;
+    }
+    cout << endl;
+
+    cout << "Number of averaging periods: " << nAveragingPeriods << endl;
+  }
+
 
 }
 

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -9445,21 +9445,15 @@ private:
    * This is a templated step in the averaging calculation.  The averaging
    * routine loops over all the nodes and calls this routine for each node.
    *
-   * This step roughly corresponds to:
-   *   // Retrieve U_current
-   *   // Retrieve U_average
-   *   dU = (U_current - U_average)*weight;
-   *   // Store dU
-   *
-   * Note that the base class already updates the average of the solution.
-   * This method should only be implemented when other variables are to be
-   * averaged.
+   * Note that the base class (CSolver) updates the average of the solution.
+   * This method is only be implemented to allow other variables to be averaged.
    *
    * \param weight - The amount to weight the update on the average
    * \param iPoint - The point at which the average will be calculated
    * \param buffer - An allocated array of size nVar for working calculations
    */
   void UpdateAverage(su2double weight, unsigned short iPoint, su2double* buffer);
+
 public:
   /*!
    * \brief Constructor of the class.
@@ -9669,15 +9663,8 @@ private:
    * This is a templated step in the averaging calculation.  The averaging
    * routine loops over all the nodes and calls this routine for each node.
    *
-   * This step roughly corresponds to:
-   *   // Retrieve U_current
-   *   // Retrieve U_average
-   *   dU = (U_current - U_average)*weight;
-   *   // Store dU
-   *
-   * Note that the base class already updates the average of the solution.
-   * This method should only be implemented when other variables are to be
-   * averaged.
+   * Note that the base class (CSolver) updates the average of the solution.
+   * This method is only be implemented to allow other variables to be averaged.
    *
    * \param weight - The amount to weight the update on the average
    * \param iPoint - The point at which the average will be calculated

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -4210,6 +4210,18 @@ public:
    */
   virtual void SetDES_LengthScale(CSolver** solver, CGeometry *geometry, CConfig *config);
 
+  /*!
+   * \brief Compute the average value of the solution variables.
+   * \param[in] solver - Solver container
+   * \param[in] geometry - Geometrical definition.
+   * \param[in] config - Definition of the particular problem.
+   */
+  void SetAverages(CGeometry* geometry, CSolver** solver, CConfig* config);
+
+  /*!
+   * \brief Initialize the average values of the solution.
+   */
+  void InitAverages(void);
 };
 
 /*!

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -129,6 +129,31 @@ protected:
   passivedouble *Restart_Data; /*!< \brief Auxiliary structure for holding the data values from a restart. */
   unsigned short nOutputVariables;  /*!< \brief Number of variables to write. */
 
+
+  /*!
+   * \brief Finish the averaging calculation.
+   *
+   * This is a templated step in the averaging calculation.  The averaging
+   * routine loops over all the nodes and calls this routine for each node.
+   *
+   * This step roughly corresponds to:
+   *   // Retrieve U_current
+   *   // Retrieve U_average
+   *   dU = (U_current - U_average)*weight;
+   *   // Store dU
+   *
+   * Note that the base class (CSolver) updates the average of the solution.
+   * This method should only be implemented in derived classes when other
+   * variables are to be averaged.
+   *
+   * \param weight - The amount to weight the update on the average
+   * \param iPoint - The point at which the average will be calculated
+   * \param buffer - An allocated array of size nVar for working calculations
+   */
+  virtual void UpdateAverage(const su2double weight,
+                             const unsigned short iPoint,
+                             su2double* buffer);
+
 public:
   
   CSysVector LinSysSol;    /*!< \brief vector to store iterative solution of implicit linear system. */
@@ -9413,7 +9438,28 @@ private:
   su2double *constants,  /*!< \brief Constants for the model. */
   kine_Inf,           /*!< \brief Free-stream turbulent kinetic energy. */
   omega_Inf;          /*!< \brief Free-stream specific dissipation. */
-  
+
+  /*!
+   * \brief Finish the averaging calculation.
+   *
+   * This is a templated step in the averaging calculation.  The averaging
+   * routine loops over all the nodes and calls this routine for each node.
+   *
+   * This step roughly corresponds to:
+   *   // Retrieve U_current
+   *   // Retrieve U_average
+   *   dU = (U_current - U_average)*weight;
+   *   // Store dU
+   *
+   * Note that the base class already updates the average of the solution.
+   * This method should only be implemented when other variables are to be
+   * averaged.
+   *
+   * \param weight - The amount to weight the update on the average
+   * \param iPoint - The point at which the average will be calculated
+   * \param buffer - An allocated array of size nVar for working calculations
+   */
+  void UpdateAverage(su2double weight, unsigned short iPoint, su2double* buffer);
 public:
   /*!
    * \brief Constructor of the class.
@@ -9598,7 +9644,6 @@ public:
    * \param[in] config - Definition of the particular problem.
    */
   void SetInlet(CConfig *config);
-  
 };
 
 
@@ -9617,6 +9662,28 @@ private:
     epsi_Inf,              /*!< \brief Free-stream specific dissipation. */
     zeta_Inf,              /*!< \brief Free-stream v2/tke ratio. */
     f_Inf;                 /*!< \brief Free-stream redistribution. */
+
+  /*!
+   * \brief Finish the averaging calculation.
+   *
+   * This is a templated step in the averaging calculation.  The averaging
+   * routine loops over all the nodes and calls this routine for each node.
+   *
+   * This step roughly corresponds to:
+   *   // Retrieve U_current
+   *   // Retrieve U_average
+   *   dU = (U_current - U_average)*weight;
+   *   // Store dU
+   *
+   * Note that the base class already updates the average of the solution.
+   * This method should only be implemented when other variables are to be
+   * averaged.
+   *
+   * \param weight - The amount to weight the update on the average
+   * \param iPoint - The point at which the average will be calculated
+   * \param buffer - An allocated array of size nVar for working calculations
+   */
+  void UpdateAverage(su2double weight, unsigned short iPoint, su2double* buffer);
 
 public:
   /*!
@@ -9787,7 +9854,6 @@ public:
    * \param[in] config - Definition of the particular problem.
    */
   void SetInlet(CConfig *config);
-
 };
 
 /*!

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -2454,12 +2454,36 @@ public:
 
   virtual su2double GetSolution_Old_Accel(unsigned short iVar);
 
+  /*!
+   * \brief Set the average solution manually.
+   * \param val_averages - An array containing the average solution
+   */
   void SetAverageSolution(const su2double* val_averages);
 
+  /*!
+   * \brief Add to the average solution.
+   * \param val_delta_averages - The amount to add to the average solution.
+   */
   void AddAverageSolution(const su2double* val_delta_averages);
 
+  /*!
+   * \brief Get an array of values representing the average solution.
+   * \return An array of values representing the average solution.
+   */
   const su2double* GetAverageSolution() const;
 
+  /*!
+   * \brief Get a component of the average solution.
+   * \param iVar - The component of the average solution to be used.
+   * \return A component of the average solution
+   */
+  su2double GetAverageSolution(const unsigned short iVar) const;
+
+  // TODO: These are hacks to be removed once the average solution is
+  // stored properly in the output.
+  su2double GetAverageSolution0();
+  su2double GetAverageSolution1();
+  su2double GetAverageSolution2();
 };
 
 /*!

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -65,6 +65,7 @@ protected:
   bool Non_Physical;      /*!< \brief Non-physical points in the solution (force first order). */
   su2double *Solution_time_n,  /*!< \brief Solution of the problem at time n for dual-time stepping technique. */
   *Solution_time_n1;      /*!< \brief Solution of the problem at time n-1 for dual-time stepping technique. */
+  su2double* Solution_Avg; /*!< \brief The runtime average of the solution */
   su2double **Gradient;    /*!< \brief Gradient of the solution of the problem. */
   su2double *Limiter;        /*!< \brief Limiter of the solution of the problem. */
   su2double *Solution_Max;    /*!< \brief Max solution for limiter computation. */
@@ -2452,6 +2453,12 @@ public:
   virtual su2double GetSolution_Old_Vel(unsigned short iVar);
 
   virtual su2double GetSolution_Old_Accel(unsigned short iVar);
+
+  void SetAverageSolution(const su2double* val_averages);
+
+  void AddAverageSolution(const su2double* val_delta_averages);
+
+  const su2double* GetAverageSolution() const;
 
 };
 

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -2496,12 +2496,6 @@ public:
    * \return A component of the average solution
    */
   su2double GetAverageSolution(const unsigned short iVar) const;
-
-  // TODO: These are hacks to be removed once the average solution is
-  // stored properly in the output.
-  su2double GetAverageSolution0();
-  su2double GetAverageSolution1();
-  su2double GetAverageSolution2();
 };
 
 /*!

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -937,6 +937,18 @@ public:
 
   /*!
    * \brief A virtual member.
+   * \return Value of turbulent timescale
+   */
+  virtual su2double GetAverageTurbTimescale(void);
+
+  /*!
+   * \brief A virtual member.
+   * \return Value of the turbulent lengthscale
+   */
+  virtual su2double GetAverageTurbLengthscale(void);
+
+  /*!
+   * \brief A virtual member.
    * \return The Reynolds stress component anisotropy ratio (max-to-min)
    */
   virtual su2double GetAnisoRatio(void);
@@ -1150,6 +1162,12 @@ public:
    */
   virtual void SetTurbScales(su2double val_turb_T, su2double val_turb_L);
 
+  /*!
+   * \brief A virtual member.
+   * \param[in] val_T_avg - The average turbulent timescale
+   * \param[in] val_L_avg - The average turbulent lengthscale
+   */
+  virtual void SetAverageTurbScales(su2double val_T_avg, su2double val_L_avg);
   /*!
    * \brief A virtual member.
    * \param[in] val_r_k - The resolution adequacy parameter for hybrid RANS/LES
@@ -4481,7 +4499,10 @@ protected:
   F2,            /*!< \brief Menter blending function for stress limiter. */
   CDkw,           /*!< \brief Cross-diffusion. */
   T,              /*!< \brief Turbulent timescale */
-  L;              /*!< \brief Turbulent lengthscale */
+  L,              /*!< \brief Turbulent lengthscale */
+  T_avg,          /*!< \brief Average turbulent timescale */
+  L_avg;          /*!< \brief Average turbulent lengthscale */
+
   
 public:
   /*!
@@ -4543,11 +4564,30 @@ public:
   su2double GetTurbLengthscale(void);
 
   /**
+   * \brief Get the average large-eddy timescale of the turbulence
+   * \return The large-eddy timescale of the turbulence.
+   */
+  su2double GetAverageTurbTimescale(void);
+
+  /**
+   * \brief Get the average large-eddy lengthscale of the turbulence
+   * \return The large-eddy lengthscale of the turbulence
+   */
+  su2double GetAverageTurbLengthscale(void);
+
+  /**
    * \brief Sets the large-eddy lengthscale and the large-eddy timescale
    * \param[in] val_turb_T - Large eddy timescale of the turbulence
    * \param[in] val_turb_L - Large eddy lengthscale of the turbulence
    */
   void SetTurbScales(su2double val_turb_T, su2double val_turb_L);
+
+  /**
+   * \brief Sets the average large-eddy lengthscale and the timescale
+   * \param[in] val_T_avg - Average large eddy timescale of the turbulence
+   * \param[in] val_L_avg - Average large eddy lengthscale of the turbulence
+   */
+  void SetAverageTurbScales(su2double val_T_avg, su2double val_L_avg);
 };
 
 /*!
@@ -4620,6 +4660,8 @@ protected:
   su2double sigma_e, sigma_k, sigma_z, C_e1o, C_e2, C1, C_2p, C_T, C_L, C_eta;
   su2double Tm,		/*!< \brief T_m k-eps. */
     Lm,		        /*!< \brief L_m k-eps */
+    Tm_avg,       /*!< \brief Average turbulent timescale */
+    Lm_avg,       /*!< \brief Average turbulent lengthscale */
     Re_T;
 
 public:
@@ -4661,6 +4703,18 @@ public:
    */
   su2double GetTurbLengthscale(void);
 
+  /**
+   * \brief Get the average large-eddy timescale of the turbulence
+   * \return The large-eddy timescale of the turbulence.
+   */
+  su2double GetAverageTurbTimescale(void);
+
+  /**
+   * \brief Get the average large-eddy lengthscale of the turbulence
+   * \return The large-eddy lengthscale of the turbulence
+   */
+  su2double GetAverageTurbLengthscale(void);
+
   /*!
    * \brief Get the component anisotropy ratio (max-to-min)
    * \return The Reynolds stress component anisotropy ratio (max-to-min)
@@ -4673,6 +4727,13 @@ public:
    * \param[in] val_turb_L - Large eddy lengthscale of the turbulence
    */
   void SetTurbScales(su2double val_turb_T, su2double val_turb_L);
+
+  /**
+   * \brief Sets the average large-eddy lengthscale and the timescale
+   * \param[in] val_T_avg - Average large eddy timescale of the turbulence
+   * \param[in] val_L_avg - Average large eddy lengthscale of the turbulence
+   */
+  void SetAverageTurbScales(su2double val_T_avg, su2double val_L_avg);
 };
 
 

--- a/SU2_CFD/include/variable_structure.inl
+++ b/SU2_CFD/include/variable_structure.inl
@@ -265,6 +265,10 @@ inline su2double CVariable::GetTurbTimescale(void) { return 0; }
 
 inline su2double CVariable::GetTurbLengthscale(void) { return 0; }
 
+inline su2double CVariable::GetAverageTurbTimescale() { return 0; }
+
+inline su2double CVariable::GetAverageTurbLengthscale() { return 0; }
+
 inline su2double CVariable::GetAnisoRatio(void) {return 1; }
 
 inline su2double CVariable::GetResolutionAdequacy(void) {return 1; }
@@ -459,6 +463,8 @@ inline void CVariable::SetLaminarViscosity(CConfig *config) { }
 inline void CVariable::SetEddyViscosity(su2double eddy_visc) { }
 
 inline void CVariable::SetTurbScales(su2double val_turb_T, su2double val_turb_L) { }
+
+inline void CVariable::SetAverageTurbScales(su2double val_T_avg, su2double val_L_avg) { }
 
 inline void CVariable::SetResolutionAdequacy(su2double val_r_k) { }
 
@@ -1445,12 +1451,25 @@ inline su2double CTurbSSTVariable::GetTurbLengthscale() {
  return L;
 }
 
+inline su2double CTurbSSTVariable::GetAverageTurbTimescale() {
+  return T_avg;
+}
+
+inline su2double CTurbSSTVariable::GetAverageTurbLengthscale() {
+ return L_avg;
+}
+
 inline void CTurbSSTVariable::SetTurbScales(su2double val_turb_T, su2double val_turb_L) {
   T = val_turb_T;
   L = val_turb_L;
 }
 
-inline su2double CTurbKEVariable::GetTurbTimescale() {
+inline void CTurbSSTVariable::SetAverageTurbScales(su2double val_T_avg, su2double val_L_avg) {
+  T_avg = val_T_avg;
+  L_avg = val_L_avg;
+}
+
+inline su2double CTurbKEVariable::GetTurbTimescale(){
   return Tm;
 }
 
@@ -1458,9 +1477,22 @@ inline su2double CTurbKEVariable::GetTurbLengthscale() {
  return Lm;
 }
 
+inline su2double CTurbKEVariable::GetAverageTurbTimescale() {
+  return Tm_avg;
+}
+
+inline su2double CTurbKEVariable::GetAverageTurbLengthscale() {
+ return Lm_avg;
+}
+
 inline void CTurbKEVariable::SetTurbScales(su2double val_turb_T, su2double val_turb_L) {
   Tm = val_turb_T;
   Lm = val_turb_L;
+}
+
+inline void CTurbKEVariable::SetAverageTurbScales(su2double val_T_avg, su2double val_L_avg) {
+  Tm_avg = val_T_avg;
+  Lm_avg = val_L_avg;
 }
 
 inline su2double* CDiscAdjVariable::GetGeometry_Direct() { return Geometry_Direct; }

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -469,6 +469,8 @@ CDriver::CDriver(char* confFile,
                                 ZONE_FLOW, ZONE_STRUCT, true);
   }
 
+
+
   /*--- Set up a timer for performance benchmarking (preprocessing time is not included) ---*/
 
 #ifndef HAVE_MPI
@@ -1013,6 +1015,16 @@ void CDriver::Solver_Preprocessing(CSolver ***solver_container, CGeometry **geom
   if (config->GetFSI_Simulation()) update_geo = false;
 
   Solver_Restart(solver_container, geometry, config, update_geo);
+
+  /*--- Initialize the averages ---*/
+
+  for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
+    solver_container[iMGlevel][FLOW_SOL]->InitAverages();
+    if (turbulent) {
+      solver_container[iMGlevel][TURB_SOL]->InitAverages();
+    }
+  }
+
 
 }
 

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -614,6 +614,16 @@ void CFluidIteration::Update(COutput *output,
     if (Physical_t >=  config_container[val_iZone]->GetTotal_UnstTime())
       integration_container[val_iZone][FLOW_SOL]->SetConvergence(true);
   }
+
+  /*--- Update averages ---*/
+
+  for (iMesh = 0; iMesh <= config_container[val_iZone]->GetnMGLevels(); iMesh++) {
+    solver_container[val_iZone][iMesh][FLOW_SOL]->SetAverages(geometry_container[val_iZone][iMesh],  solver_container[val_iZone][iMesh], config_container[val_iZone]);
+  }
+  if ((config_container[val_iZone]->GetKind_Solver() == RANS) ||
+      (config_container[val_iZone]->GetKind_Solver() == DISC_ADJ_RANS)) {
+    solver_container[val_iZone][MESH_0][TURB_SOL]->SetAverages(geometry_container[val_iZone][MESH_0],  solver_container[val_iZone][iMesh], config_container[val_iZone]);
+  }
 }
 
 void CFluidIteration::Monitor()     { }

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -622,7 +622,7 @@ void CFluidIteration::Update(COutput *output,
   }
   if ((config_container[val_iZone]->GetKind_Solver() == RANS) ||
       (config_container[val_iZone]->GetKind_Solver() == DISC_ADJ_RANS)) {
-    solver_container[val_iZone][MESH_0][TURB_SOL]->SetAverages(geometry_container[val_iZone][MESH_0],  solver_container[val_iZone][iMesh], config_container[val_iZone]);
+    solver_container[val_iZone][MESH_0][TURB_SOL]->SetAverages(geometry_container[val_iZone][MESH_0],  solver_container[val_iZone][MESH_0], config_container[val_iZone]);
   }
 }
 

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -616,13 +616,16 @@ void CFluidIteration::Update(COutput *output,
   }
 
   /*--- Update averages ---*/
-
-  for (iMesh = 0; iMesh <= config_container[val_iZone]->GetnMGLevels(); iMesh++) {
-    solver_container[val_iZone][iMesh][FLOW_SOL]->SetAverages(geometry_container[val_iZone][iMesh],  solver_container[val_iZone][iMesh], config_container[val_iZone]);
-  }
-  if ((config_container[val_iZone]->GetKind_Solver() == RANS) ||
-      (config_container[val_iZone]->GetKind_Solver() == DISC_ADJ_RANS)) {
-    solver_container[val_iZone][MESH_0][TURB_SOL]->SetAverages(geometry_container[val_iZone][MESH_0],  solver_container[val_iZone][MESH_0], config_container[val_iZone]);
+  if (config_container[val_iZone]->GetKind_Averaging() != NO_AVERAGING) {
+    /*--- We check this when setting up, so this assert should never be false ---*/
+    assert(config_container[val_iZone]->GetUnsteady_Simulation() != STEADY);
+    for (iMesh = 0; iMesh <= config_container[val_iZone]->GetnMGLevels(); iMesh++) {
+      solver_container[val_iZone][iMesh][FLOW_SOL]->SetAverages(geometry_container[val_iZone][iMesh],  solver_container[val_iZone][iMesh], config_container[val_iZone]);
+    }
+    if ((config_container[val_iZone]->GetKind_Solver() == RANS) ||
+        (config_container[val_iZone]->GetKind_Solver() == DISC_ADJ_RANS)) {
+      solver_container[val_iZone][MESH_0][TURB_SOL]->SetAverages(geometry_container[val_iZone][MESH_0],  solver_container[val_iZone][MESH_0], config_container[val_iZone]);
+    }
   }
 }
 

--- a/SU2_CFD/src/output_cgns.cpp
+++ b/SU2_CFD/src/output_cgns.cpp
@@ -433,6 +433,15 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
     if (cgns_err) cg_error_print();
   }
   
+  /*--- Write averages to CGNS file ---*/
+  if (config->GetKind_Averaging() != NO_AVERAGING) {
+    for (jVar = 0; jVar < nVar_Consv; jVar++) {
+      name.str(string()); name << "Average " << jVar+1;
+      cgns_err = cg_field_write(cgns_file, cgns_base, cgns_zone, cgns_flow, RealDouble,(char *)name.str().c_str(), Data[iVar], &cgns_field); iVar++;
+      if (cgns_err) cg_error_print();
+    }
+  }
+
   /*--- Write primitive variable residuals to CGNS file ---*/
   if (config->GetWrt_Limiters()) {
     for (jVar = 0; jVar < nVar_Consv; jVar++) {

--- a/SU2_CFD/src/output_fieldview.cpp
+++ b/SU2_CFD/src/output_fieldview.cpp
@@ -201,6 +201,12 @@ void COutput::SetFieldViewASCII(CConfig *config, CGeometry *geometry, unsigned s
     
     /*--- Add names for any extra variables (this will need to be adjusted). ---*/
 
+    if (config->GetKind_Averaging()) {
+      for (iVar = 0; iVar < nVar_Consv; iVar++) {
+        FieldView_File << "Average_" << iVar+1 << endl;
+      }
+    }
+
     if (config->GetWrt_Limiters()) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
         FieldView_File << "Limiter_" << iVar+1 << endl;

--- a/SU2_CFD/src/output_paraview.cpp
+++ b/SU2_CFD/src/output_paraview.cpp
@@ -418,6 +418,27 @@ void COutput::SetParaview_ASCII(CConfig *config, CGeometry *geometry, unsigned s
       VarCounter++;
     }
     
+    if (config->GetKind_Averaging() != NO_AVERAGING) {
+      for (iVar = 0; iVar < nVar_Consv; iVar++) {
+
+        Paraview_File << "\nSCALARS Average_" << iVar+1 << " float 1\n";
+        Paraview_File << "LOOKUP_TABLE default\n";
+
+        for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
+          if (surf_sol) {
+            if (LocalIndex[iPoint+1] != 0) {
+              /*--- Loop over the vars/residuals and write the values to file ---*/
+              Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+            }
+          } else {
+            /*--- Loop over the vars/residuals and write the values to file ---*/
+            Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+          }
+        }
+        VarCounter++;
+      }
+    }
+
     if (config->GetWrt_Limiters()) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
         
@@ -1407,6 +1428,27 @@ void COutput::SetParaview_MeshASCII(CConfig *config, CGeometry *geometry, unsign
         }
       }
       VarCounter++;
+    }
+
+    if (config->GetKind_Averaging() != NO_AVERAGING) {
+      for (iVar = 0; iVar < nVar_Consv; iVar++) {
+
+        Paraview_File << "\nSCALARS Average_" << iVar+1 << " float 1\n";
+        Paraview_File << "LOOKUP_TABLE default\n";
+
+        for (iPoint = 0; iPoint < nGlobal_Poin; iPoint++) {
+          if (surf_sol) {
+            if (LocalIndex[iPoint+1] != 0) {
+              /*--- Loop over the vars/residuals and write the values to file ---*/
+              Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+            }
+          } else {
+            /*--- Loop over the vars/residuals and write the values to file ---*/
+            Paraview_File << scientific << Data[VarCounter][iPoint] << "\t";
+          }
+        }
+        VarCounter++;
+      }
     }
     
     if (config->GetWrt_Limiters()) {

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -439,18 +439,11 @@ void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
 
   for (unsigned short iZone = 0; iZone < val_nZone; iZone++) {
     unsigned short Kind_Solver  = config[iZone]->GetKind_Solver();
-    // XXX: Hacked output. We need functors now!
-    RegisterScalar("Avg_X-Momentum", "Avg_X-Momentum", FLOW_SOL,
-                   &CVariable::GetAverageSolution1, iZone);
-    RegisterScalar("Avg_Y-Momentum", "Avg_Y-Momentum", FLOW_SOL,
-                   &CVariable::GetAverageSolution2, iZone);
 
     if (Kind_Solver == RANS) {
 
       if (config[iZone]->GetKind_Turb_Model() == KE ||
           config[iZone]->GetKind_Turb_Model() == SST) {
-        RegisterScalar("Avg_TKE", "Avg_TKE", TURB_SOL,
-                       &CVariable::GetAverageSolution0, iZone);
         RegisterScalar("L_m", "L<sub>m</sub>", TURB_SOL,
                        &CVariable::GetTurbLengthscale, iZone);
         RegisterScalar("T_m", "T<sub>m</sub>", TURB_SOL,
@@ -2382,6 +2375,7 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
                          ( config->GetKind_Solver() == ADJ_RANS          )   );
   bool fem = (config->GetKind_Solver() == FEM_ELASTICITY);
   const bool dynamic_hybrid = (config->GetKind_HybridRANSLES() == DYNAMIC_HYBRID);
+  const bool runtime_average = (config->GetKind_Averaging() != NO_AVERAGING);
   
   unsigned short iDim, jDim;
   unsigned short nDim = geometry->GetnDim();
@@ -2448,6 +2442,10 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
     
     if (config->GetWrt_Residuals()) nVar_Total += nVar_Consv;
     
+    /*--- Add the average values ---*/
+
+    if (runtime_average) nVar_Total += nVar_Consv;
+
     /*--- Add the grid velocity to the restart file for the unsteady adjoint ---*/
     
     if (grid_movement && !fem) {
@@ -2608,12 +2606,15 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
   su2double *Buffer_Send_Var = new su2double[MaxLocalPoint];
   su2double *Buffer_Recv_Var = NULL;
   
+  su2double *Buffer_Send_Avg = new su2double[MaxLocalPoint];
+  su2double *Buffer_Recv_Avg = NULL;
+
   su2double *Buffer_Send_Res = new su2double[MaxLocalPoint];
   su2double *Buffer_Recv_Res = NULL;
   
   su2double *Buffer_Send_Vol = new su2double[MaxLocalPoint];
   su2double *Buffer_Recv_Vol = NULL;
-  
+
   unsigned long *Buffer_Send_GlobalIndex = new unsigned long[MaxLocalPoint];
   unsigned long *Buffer_Recv_GlobalIndex = NULL;
   
@@ -2641,6 +2642,7 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
   if (rank == MASTER_NODE) {
     
     Buffer_Recv_Var = new su2double[size*MaxLocalPoint];
+    Buffer_Recv_Avg = new su2double[size*MaxLocalPoint];
     Buffer_Recv_Res = new su2double[size*MaxLocalPoint];
     Buffer_Recv_Vol = new su2double[size*MaxLocalPoint];
     Buffer_Recv_GlobalIndex = new unsigned long[size*MaxLocalPoint];
@@ -2689,6 +2691,10 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
         /*--- Get this variable into the temporary send buffer. ---*/
         
         Buffer_Send_Var[jPoint] = solver[CurrentIndex]->node[iPoint]->GetSolution(jVar);
+
+        if (runtime_average) {
+          Buffer_Send_Avg[jPoint] = solver[CurrentIndex]->node[iPoint]->GetAverageSolution(jVar);
+        }
         
         if (!config->GetLow_MemoryOutput()) {
           
@@ -2725,6 +2731,15 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
 #else
     for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++) Buffer_Recv_Var[iPoint] = Buffer_Send_Var[iPoint];
 #endif
+
+    if (runtime_average) {
+#ifdef HAVE_MPI
+      SU2_MPI::Gather(Buffer_Send_Avg, nBuffer_Scalar, MPI_DOUBLE, Buffer_Recv_Avg, nBuffer_Scalar, MPI_DOUBLE, MASTER_NODE, MPI_COMM_WORLD);
+#else
+      for (iPoint = 0; iPoint < nBuffer_Scalar; iPoint++) Buffer_Recv_Avg[iPoint] = Buffer_Send_Avg[iPoint];
+#endif
+    }
+
     if (!config->GetLow_MemoryOutput()) {
       
       if (config->GetWrt_Limiters()) {
@@ -2744,6 +2759,7 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
       }
       
     }
+
     
     if (iVar == 0) {
 #ifdef HAVE_MPI
@@ -2766,21 +2782,25 @@ void COutput::MergeSolution(CConfig *config, CGeometry *geometry, CSolver **solv
           
           Data[iVar][iGlobal_Index] = Buffer_Recv_Var[jPoint];
           
+          unsigned short ExtraIndex = nVar_Consv;
+          if (runtime_average) {
+            Data[iVar+ExtraIndex][iGlobal_Index] = Buffer_Recv_Avg[jPoint];
+            ExtraIndex += nVar_Consv;
+          }
+
           if (!config->GetLow_MemoryOutput()) {
             
             if (config->GetWrt_Limiters()) {
-              Data[iVar+nVar_Consv][iGlobal_Index] = Buffer_Recv_Vol[jPoint];
+              Data[iVar+ExtraIndex][iGlobal_Index] = Buffer_Recv_Vol[jPoint];
+              ExtraIndex += nVar_Consv;
             }
             
             if (config->GetWrt_Residuals()) {
-              unsigned short ExtraIndex;
-              ExtraIndex = nVar_Consv;
-              if (config->GetWrt_Limiters()) ExtraIndex = 2*nVar_Consv;
               Data[iVar+ExtraIndex][iGlobal_Index] = Buffer_Recv_Res[jPoint];
             }
             
           }
-          
+
           jPoint++;
         }
         /*--- Adjust jPoint to index of next proc's data in the buffers. ---*/
@@ -4341,6 +4361,12 @@ void COutput::SetRestart(CConfig *config, CGeometry *geometry, CSolver **solver,
       restart_file << "\t\"Conservative_" << iVar+1<<"\"";
   }
   
+  if (config->GetKind_Averaging() != NO_AVERAGING) {
+    for (iVar = 0; iVar < nVar_Consv; iVar++) {
+      restart_file << "\t\"Average_" << iVar+1 <<"\"";
+    }
+  }
+
   if (!config->GetLow_MemoryOutput()) {
     
     if (config->GetWrt_Limiters()) {
@@ -12438,6 +12464,41 @@ void COutput::LoadLocalData_Flow(CConfig *config, CGeometry *geometry, CSolver *
   }
   if (incompressible && weakly_coupled_heat) Variable_Names.push_back("Temperature");
 
+  /*--- Add the average solution ---*/
+
+  if (config->GetKind_Averaging() != NO_AVERAGING) {
+    nVar_Par += nVar_Consv_Par;
+    if (incompressible) {
+      Variable_Names.push_back("Average_Pressure");
+      Variable_Names.push_back("Average_X-Momentum");
+      Variable_Names.push_back("Average_Y-Momentum");
+      if (geometry->GetnDim() == 3) Variable_Names.push_back("Average_Z-Momentum");
+    } else {
+      Variable_Names.push_back("Average_Density");
+      Variable_Names.push_back("Average_X-Momentum");
+      Variable_Names.push_back("Average_Y-Momentum");
+      if (geometry->GetnDim() == 3) Variable_Names.push_back("Average_Z-Momentum");
+      Variable_Names.push_back("Average_Energy");
+    }
+    if (SecondIndex != NONE) {
+      if (config->GetKind_Turb_Model() == SST) {
+        Variable_Names.push_back("Average_TKE");
+        Variable_Names.push_back("Average_Omega");
+      } else if (config->GetKind_Turb_Model() == KE) {
+        Variable_Names.push_back("Average_TKE");
+        Variable_Names.push_back("Average_Dissipation");
+        Variable_Names.push_back("Average_v2");
+        Variable_Names.push_back("Average_f");
+      } else {
+        /*--- S-A variants ---*/
+        Variable_Names.push_back("Average_Nu_Tilde");
+      }
+    }
+    if (dynamic_hybrid) {
+      Variable_Names.push_back("Average_Alpha");
+    }
+  }
+
   /*--- If requested, register the limiter and residuals for all of the
    equations in the current flow problem. ---*/
   
@@ -12780,6 +12841,29 @@ void COutput::LoadLocalData_Flow(CConfig *config, CGeometry *geometry, CSolver *
       if (incompressible && weakly_coupled_heat) {
         Local_Data[jPoint][iVar] = solver[HEAT_SOL]->node[iPoint]->GetSolution(0);
         iVar++;
+      }
+
+      /*--- Averages ---*/
+      if (config->GetKind_Averaging() != NO_AVERAGING) {
+        /*--- Mean Flow Averages ---*/
+        for (jVar = 0; jVar < nVar_First; jVar++) {
+          Local_Data[jPoint][iVar] = solver[FirstIndex]->node[iPoint]->GetAverageSolution(jVar);
+          iVar++;
+        }
+        /*--- RANS Averages ---*/
+        if (SecondIndex != NONE) {
+          for (jVar = 0; jVar < nVar_Second; jVar++) {
+            Local_Data[jPoint][iVar] = solver[SecondIndex]->node[iPoint]->GetAverageSolution(jVar);
+            iVar++;
+          }
+        }
+        /*--- Dynamic hybrid RANS/LES Averages ---*/
+        if (ThirdIndex != NONE && dynamic_hybrid) {
+          for (jVar = 0; jVar < nVar_Third; jVar++) {
+            Local_Data[jPoint][iVar] = solver[ThirdIndex]->node[iPoint]->GetAverageSolution(jVar);
+            iVar++;
+          }
+        }
       }
 
       /*--- If limiters and/or residuals are requested. ---*/

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -444,20 +444,25 @@ void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
                    &CVariable::GetAverageSolution1, iZone);
     RegisterScalar("Avg_Y-Momentum", "Avg_Y-Momentum", FLOW_SOL,
                    &CVariable::GetAverageSolution2, iZone);
-    if (Kind_Solver == RANS)
-      RegisterScalar("Avg_TKE", "Avg_TKE", TURB_SOL,
-                     &CVariable::GetAverageSolution0, iZone);
+
     if (Kind_Solver == RANS) {
-      const bool dynamic_hybrid =
-          (config[iZone]->GetKind_HybridRANSLES() == DYNAMIC_HYBRID);
 
       if (config[iZone]->GetKind_Turb_Model() == KE ||
           config[iZone]->GetKind_Turb_Model() == SST) {
+        RegisterScalar("Avg_TKE", "Avg_TKE", TURB_SOL,
+                       &CVariable::GetAverageSolution0, iZone);
         RegisterScalar("L_m", "L<sub>m</sub>", TURB_SOL,
                        &CVariable::GetTurbLengthscale, iZone);
         RegisterScalar("T_m", "T<sub>m</sub>", TURB_SOL,
                        &CVariable::GetTurbTimescale, iZone);
+        RegisterScalar("Avg_L_m", "L<sub>m,avg</sub>", TURB_SOL,
+                       &CVariable::GetAverageTurbLengthscale, iZone);
+        RegisterScalar("Avg_T_m", "T<sub>m,avg</sub>", TURB_SOL,
+                       &CVariable::GetAverageTurbTimescale, iZone);
       }
+
+      const bool dynamic_hybrid =
+          (config[iZone]->GetKind_HybridRANSLES() == DYNAMIC_HYBRID);
   
       if (dynamic_hybrid) {
         if (config[iZone]->GetKind_Hybrid_Anisotropy_Model() != ISOTROPIC) {

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -439,11 +439,20 @@ void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
 
   for (unsigned short iZone = 0; iZone < val_nZone; iZone++) {
     unsigned short Kind_Solver  = config[iZone]->GetKind_Solver();
+    // XXX: Hacked output. We need functors now!
+    RegisterScalar("Avg_X-Momentum", "Avg_X-Momentum", FLOW_SOL,
+                   &CVariable::GetAverageSolution1, iZone);
+    RegisterScalar("Avg_Y-Momentum", "Avg_Y-Momentum", FLOW_SOL,
+                   &CVariable::GetAverageSolution2, iZone);
+    if (Kind_Solver == RANS)
+      RegisterScalar("Avg_TKE", "Avg_TKE", TURB_SOL,
+                     &CVariable::GetAverageSolution0, iZone);
     if (Kind_Solver == RANS) {
       const bool dynamic_hybrid =
           (config[iZone]->GetKind_HybridRANSLES() == DYNAMIC_HYBRID);
 
-      if (config[iZone]->GetKind_Turb_Model() == KE) {
+      if (config[iZone]->GetKind_Turb_Model() == KE ||
+          config[iZone]->GetKind_Turb_Model() == SST) {
         RegisterScalar("L_m", "L<sub>m</sub>", TURB_SOL,
                        &CVariable::GetTurbLengthscale, iZone);
         RegisterScalar("T_m", "T<sub>m</sub>", TURB_SOL,

--- a/SU2_CFD/src/output_tecplot.cpp
+++ b/SU2_CFD/src/output_tecplot.cpp
@@ -149,6 +149,12 @@ void COutput::SetTecplotASCII(CConfig *config, CGeometry *geometry, CSolver **so
       Tecplot_File << ",\"Conservative_" << iVar+1 << "\"";
     }
     
+    if (config->GetKind_Averaging() != NO_AVERAGING) {
+      for (iVar = 0; iVar < nVar_Consv; iVar++) {
+        Tecplot_File << ",\"Average_" << iVar+1 << "\"";
+      }
+    }
+
     if (!config->GetLow_MemoryOutput()) {
       
       if (config->GetWrt_Limiters()) {
@@ -3026,6 +3032,11 @@ string COutput::AssembleVariableNames(CGeometry *geometry, CConfig *config, unsi
     
     for (iVar = 0; iVar < nVar_Consv; iVar++) {
       variables << "Conservative_" << iVar+1<<" "; *NVar += 1;
+    }
+    if (config->GetKind_Averaging()) {
+      for (iVar = 0; iVar < nVar_Consv; iVar++) {
+        variables << "Average_" << iVar+1<<" "; *NVar += 1;
+      }
     }
     if (config->GetWrt_Limiters()) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -14176,6 +14176,24 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
       node[iPoint_Local]->SetSolution(Solution);
       iPoint_Global_Local++;
 
+      /*--- Read in the runtime averages ---*/
+
+      if (config->GetKind_Averaging() != NO_AVERAGING) {
+        unsigned short nVar_Solution = nVar;
+        if (turb_model != NO_TURB_MODEL) {
+          nVar_Solution += solver[MESH_0][TURB_SOL]->GetnVar();
+        }
+
+        unsigned short nVar_Total = nVar_Solution;
+        if (config->GetWrt_Limiters()) nVar_Total += nVar_Solution;
+        if (config->GetWrt_Residuals()) nVar_Total += nVar_Solution;
+
+        index = counter*Restart_Vars[1] + skipVars + nVar_Total;
+        for (iVar = 0; iVar < nVar; iVar++)
+          Solution[iVar] = Restart_Data[index+iVar];
+        node[iPoint_Local]->SetAverageSolution(Solution);
+      }
+
       /*--- For dynamic meshes, read in and store the
        grid coordinates and grid velocities for each node. ---*/
 
@@ -14188,6 +14206,8 @@ void CEulerSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig 
           index++;
         } else if (turb_model == SST) {
           index+=2;
+        } else if (turb_model == KE) {
+          index+=4;
         }
 
         /*--- Read in the next 2 or 3 variables which are the grid velocities ---*/

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -3690,6 +3690,11 @@ void CTurbSSTSolver::Postprocessing(CGeometry *geometry, CSolver **solver_contai
     zeta = min(1.0/omega, a1/(strMag*F2));
     muT = min(max(rho*kine*zeta,0.0),1.0);
     node[iPoint]->SetmuT(muT);
+
+    /*--- Compute T/L ---*/
+
+    const su2double L = sqrt(kine)*zeta;
+    node[iPoint]->SetTurbScales(zeta, L);
     
   }
   

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -4537,6 +4537,48 @@ void CTurbSSTSolver::SetInlet(CConfig* config) {
 
 }
 
+void CTurbSSTSolver::UpdateAverage(const su2double weight,
+                                   const unsigned short iPoint,
+                                   su2double* buffer) {
+
+  const su2double T_avg = node[iPoint]->GetAverageTurbTimescale();
+  const su2double L_avg = node[iPoint]->GetAverageTurbLengthscale();
+  const su2double T_new = T_avg + (node[iPoint]->GetTurbTimescale() - T_avg)*weight;
+  const su2double L_new = L_avg + (node[iPoint]->GetTurbLengthscale() - L_avg)*weight;
+
+#ifndef NDEBUG
+  if (T_avg > 1E16) {
+    std::stringstream error_msg;
+    error_msg << "Average turbulent timescale was unusually large.\n";
+    error_msg << "Average turbulent timescale: " << T_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+  if (T_avg < 0) {
+    std::stringstream error_msg;
+    error_msg << "Average turbulent timescale less than zero.\n";
+    error_msg << "Average turbulent timescale: " << T_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+  if (L_avg > 1E16) {
+    std::stringstream error_msg;
+    error_msg << "Average lengthscale was unusually large.\n";
+    error_msg << "Average turbulent lengthscale: " << L_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+  if (L_avg < 0) {
+    std::stringstream error_msg;
+    error_msg << "Average lengthscale was less than zero.\n";
+    error_msg << "Average turbulent lengthscale: " << L_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+#endif
+
+  node[iPoint]->SetAverageTurbScales(T_new, L_new);
+
+  /*--- Call the base class solver to compute solution average. ---*/
+  CSolver::UpdateAverage(weight, iPoint, buffer);
+}
+
 CTurbKESolver::CTurbKESolver(void) : CTurbSolver() {
 
   /*--- Array initialization ---*/
@@ -5547,4 +5589,47 @@ void CTurbKESolver::SetInlet(CConfig* config) {
     }
   }
 
+}
+
+
+void CTurbKESolver::UpdateAverage(const su2double weight,
+                                  const unsigned short iPoint,
+                                  su2double* buffer) {
+
+  const su2double T_avg = node[iPoint]->GetAverageTurbTimescale();
+  const su2double L_avg = node[iPoint]->GetAverageTurbLengthscale();
+  const su2double T_new = T_avg + (node[iPoint]->GetTurbTimescale() - T_avg)*weight;
+  const su2double L_new = L_avg + (node[iPoint]->GetTurbLengthscale() - L_avg)*weight;
+
+#ifndef NDEBUG
+  if (T_avg > 1E16) {
+    std::stringstream error_msg;
+    error_msg << "Average turbulent timescale was unusually large.\n";
+    error_msg << "Average turbulent timescale: " << T_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+  if (T_avg < 0) {
+    std::stringstream error_msg;
+    error_msg << "Average turbulent timescale less than zero.\n";
+    error_msg << "Average turbulent timescale: " << T_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+  if (L_avg > 1E16) {
+    std::stringstream error_msg;
+    error_msg << "Average lengthscale was unusually large.\n";
+    error_msg << "Average turbulent lengthscale: " << L_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+  if (L_avg < 0) {
+    std::stringstream error_msg;
+    error_msg << "Average lengthscale was less than zero.\n";
+    error_msg << "Average turbulent lengthscale: " << L_new << endl;
+    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+  }
+#endif
+
+  node[iPoint]->SetAverageTurbScales(T_new, L_new);
+
+  /*--- Call the base class solver to compute solution average. ---*/
+  CSolver::UpdateAverage(weight, iPoint, buffer);
 }

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -2921,6 +2921,37 @@ void CSolver::Read_SU2_Restart_Metadata(CGeometry *geometry, CConfig *config, bo
 
 }
 
+void CSolver::SetAverages(CGeometry* geometry, CSolver** solver,
+                          CConfig* config) {
+
+  su2double* dU = new su2double[nVar];
+  for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
+
+    const su2double TurbT = solver[TURB_SOL]->node[iPoint]->GetTurbTimescale();
+    // TODO: Check that this config setting updates correctly
+    // TODO: Nondimensional or dimensional?
+    const su2double dt = config->GetDelta_UnstTimeND();
+    const su2double* average = node[iPoint]->GetAverageSolution();
+    const su2double* current = node[iPoint]->GetSolution();
+    const su2double N_T = 4; // Averaging periods, roughly speaking
+
+    // TODO: Mass-weighted?
+    for (unsigned short iVar = 0; iVar < nVar; iVar++) {
+      dU[iVar] = (average[iVar] - current[iVar])/(N_T * TurbT);
+    }
+
+    node[iPoint]->AddAverageSolution(dU);
+  }
+
+  delete [] dU;
+}
+
+void CSolver::InitAverages() {
+  for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
+    node[iPoint]->SetAverageSolution(node[iPoint]->GetSolution());
+  }
+}
+
 CBaselineSolver::CBaselineSolver(void) : CSolver() { }
 
 CBaselineSolver::CBaselineSolver(CGeometry *geometry, CConfig *config) {

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -2946,6 +2946,15 @@ void CSolver::SetAverages(CGeometry* geometry, CSolver** solver,
     timescale = config->GetRefLength()/config->GetModVel_FreeStream();
     timescale /= config->GetTime_Ref();
     assert(timescale > 0);
+  } else if (config->GetKind_Averaging_Period() == MAX_TURB_TIMESCALE) {
+    su2double local_max_timescale = 0;
+    for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
+      timescale = solver[TURB_SOL]->node[iPoint]->GetAverageTurbTimescale();
+      local_max_timescale = max(timescale, local_max_timescale);
+    }
+    SU2_MPI::Allreduce(&local_max_timescale, &timescale, 1,
+                       MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+    assert(timescale > 0);
   }
 
   su2double* buffer = new su2double[nVar];

--- a/SU2_CFD/src/variable_direct_turbulent.cpp
+++ b/SU2_CFD/src/variable_direct_turbulent.cpp
@@ -188,6 +188,8 @@ CTurbSSTVariable::CTurbSSTVariable(su2double val_kine, su2double val_omega, su2d
 
   L = sqrt(val_kine)/val_omega;
   T = 1.0/val_omega;
+  L_avg = L;
+  T_avg = T;
 
   /*--- Allocate and initialize solution for the dual time strategy ---*/
   
@@ -262,6 +264,8 @@ CTurbKEVariable::CTurbKEVariable(su2double val_kine, su2double val_epsi,
   Solution[3] = val_f;	Solution_Old[3] = val_f;
   Tm  = val_Tm;
   Lm  = val_Lm;
+  Tm_avg = val_Tm;
+  Lm_avg = val_Lm;
 
   /*--- Initialization of eddy viscosity ---*/  
   muT = val_muT;

--- a/SU2_CFD/src/variable_structure.cpp
+++ b/SU2_CFD/src/variable_structure.cpp
@@ -466,6 +466,22 @@ const su2double* CVariable::GetAverageSolution() const {
   return Solution_Avg;
 }
 
+su2double CVariable::GetAverageSolution(unsigned short iVar) const {
+  return Solution_Avg[iVar];
+}
+
+su2double CVariable::GetAverageSolution0() {
+  return Solution_Avg[0];
+}
+
+su2double CVariable::GetAverageSolution1() {
+  return Solution_Avg[1];
+}
+
+su2double CVariable::GetAverageSolution2() {
+  return Solution_Avg[2];
+}
+
 CBaselineVariable::CBaselineVariable(void) : CVariable() { }
 
 CBaselineVariable::CBaselineVariable(su2double *val_solution, unsigned short val_nvar, CConfig *config) : CVariable(val_nvar, config) {

--- a/SU2_CFD/src/variable_structure.cpp
+++ b/SU2_CFD/src/variable_structure.cpp
@@ -458,8 +458,29 @@ void CVariable::SetAverageSolution(const su2double* val_averages) {
 }
 
 void CVariable::AddAverageSolution(const su2double* val_delta_averages) {
-  for (unsigned short iVar = 0; iVar < nVar; iVar++)
+  for (unsigned short iVar = 0; iVar < nVar; iVar++) {
     Solution_Avg[iVar] += val_delta_averages[iVar];
+#ifndef NDEBUG
+    if (Solution_Avg[iVar] > 1E16) {
+      std::stringstream error_msg;
+      error_msg << "Solution average was unusually large.\n";
+      error_msg << "Context:\n";
+      error_msg << "    iVar:         " << iVar << endl;
+      error_msg << "    Solution_Avg: " << Solution_Avg[iVar] << endl;
+      error_msg << "    delta:        " << val_delta_averages[iVar] << endl;
+      SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+    }
+    if (Solution_Avg[iVar] < -1E16) {
+      std::stringstream error_msg;
+      error_msg << "Solution average was unusually small.\n";
+      error_msg << "Context:\n";
+      error_msg << "    iVar:         " << iVar << endl;
+      error_msg << "    Solution_Avg: " << Solution_Avg[iVar] << endl;
+      error_msg << "    delta:        " << val_delta_averages[iVar] << endl;
+      SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+    }
+#endif
+  }
 }
 
 const su2double* CVariable::GetAverageSolution() const {

--- a/SU2_CFD/src/variable_structure.cpp
+++ b/SU2_CFD/src/variable_structure.cpp
@@ -46,6 +46,7 @@ CVariable::CVariable(void) {
   Solution_Old = NULL;
   Solution_time_n = NULL;
   Solution_time_n1 = NULL;
+  Solution_Avg = NULL;
   Gradient = NULL;
   Limiter = NULL;
   Solution_Max = NULL;
@@ -67,6 +68,7 @@ CVariable::CVariable(unsigned short val_nvar, CConfig *config) {
   Solution_Old = NULL;
   Solution_time_n = NULL;
   Solution_time_n1 = NULL;
+  Solution_Avg = NULL;
   Gradient = NULL;
   Limiter = NULL;
   Solution_Max = NULL;
@@ -91,6 +93,8 @@ CVariable::CVariable(unsigned short val_nvar, CConfig *config) {
   for (unsigned short iVar = 0; iVar < nVar; iVar++)
     Solution[iVar] = 0.0;
   
+  // TODO: Wrap this in a conditional branch based on config settings
+  Solution_Avg = new su2double[nVar];
 }
 
 CVariable::CVariable(unsigned short val_nDim, unsigned short val_nvar, CConfig *config) {
@@ -102,6 +106,7 @@ CVariable::CVariable(unsigned short val_nDim, unsigned short val_nvar, CConfig *
   Solution_Old = NULL;
   Solution_time_n = NULL;
   Solution_time_n1 = NULL;
+  Solution_Avg = NULL;
   Gradient = NULL;
   Limiter = NULL;
   Solution_Max = NULL;
@@ -145,6 +150,8 @@ CVariable::CVariable(unsigned short val_nDim, unsigned short val_nvar, CConfig *
 	  Solution_Adj_Old = new su2double [nVar];
 	}
   
+  // TODO: Wrap this in a conditional branch based on config settings
+  Solution_Avg = new su2double[nVar];
 }
 
 CVariable::~CVariable(void) {
@@ -154,6 +161,7 @@ CVariable::~CVariable(void) {
   if (Solution_Old        != NULL) delete [] Solution_Old;
   if (Solution_time_n     != NULL) delete [] Solution_time_n;
   if (Solution_time_n1    != NULL) delete [] Solution_time_n1;
+  if (Solution_Avg        != NULL) delete [] Solution_Avg;
   if (Limiter             != NULL) delete [] Limiter;
   if (Solution_Max        != NULL) delete [] Solution_Max;
   if (Solution_Min        != NULL) delete [] Solution_Min;
@@ -441,6 +449,21 @@ su2double CVariable::GetRKSubstepResidual(unsigned short iRKStep,
                                           unsigned short iVar    ) {
   assert(rk_stage_vectors!=NULL);
   return rk_stage_vectors[iRKStep][iVar];
+}
+
+void CVariable::SetAverageSolution(const su2double* val_averages) {
+  // Copy values; We don't want to inadverently change the pointed-to-values
+  for (unsigned short iVar = 0; iVar < nVar; iVar++)
+    Solution_Avg[iVar] = val_averages[iVar];
+}
+
+void CVariable::AddAverageSolution(const su2double* val_delta_averages) {
+  for (unsigned short iVar = 0; iVar < nVar; iVar++)
+    Solution_Avg[iVar] += val_delta_averages[iVar];
+}
+
+const su2double* CVariable::GetAverageSolution() const {
+  return Solution_Avg;
 }
 
 CBaselineVariable::CBaselineVariable(void) : CVariable() { }

--- a/SU2_CFD/src/variable_structure.cpp
+++ b/SU2_CFD/src/variable_structure.cpp
@@ -491,17 +491,6 @@ su2double CVariable::GetAverageSolution(unsigned short iVar) const {
   return Solution_Avg[iVar];
 }
 
-su2double CVariable::GetAverageSolution0() {
-  return Solution_Avg[0];
-}
-
-su2double CVariable::GetAverageSolution1() {
-  return Solution_Avg[1];
-}
-
-su2double CVariable::GetAverageSolution2() {
-  return Solution_Avg[2];
-}
 
 CBaselineVariable::CBaselineVariable(void) : CVariable() { }
 

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1265,3 +1265,15 @@ DEFINITION_DV= ( 1, 1.0 | airfoil | 0, 0.05 ); ( 1, 1.0 | airfoil | 0, 0.10 ); (
 %
 % Use combined objective within gradient evaluation: may reduce cost to compute gradients when using the adjoint formulation.
 OPT_COMBINE_OBJECTIVE = NO
+
+% -------------------- RUNTIME AVERAGING OPTIONS ---------------------------- %
+%
+% Type of averaging to be performed. (NONE, POINTWISE)
+RUNTIME_AVERAGING= NONE
+%
+% Type of time period over which the averaging will be applied.
+% (FLOW_TIMESCALE, TURB_TIMESCALE, MAX_TURB_TIMESCALE)
+AVERAGING_PERIOD= TURB_TIMESCALE
+%
+% Number of time periods over which to average (can be a non-integer)
+NUM_AVERAGING_PERIODS= 4.0


### PR DESCRIPTION
This branch implements averaging in SU2.  It does *not* use a PDE or its own solver class to implement the averages.  Instead, it uses the existing `CSolver` and `CVariable` base classes to add averages to all solution variables.  This was simpler and more straightforward, so I implemented it first. The `UpdateAverage` function can also be implemented by any solver class to compute other average quantities.  This is already done with the turbulent lengthscale and turbulent timescale.

I have added several config options too:

    % -------------------- RUNTIME AVERAGING OPTIONS ---------------------------- %
    %
    % Type of averaging to be performed. (NONE, POINTWISE)
    RUNTIME_AVERAGING= NONE
    %
    % Type of time period over which the averaging will be applied.
    % (FLOW_TIMESCALE, TURB_TIMESCALE, MAX_TURB_TIMESCALE)
    AVERAGING_PERIOD= TURB_TIMESCALE
    %
    % Number of time periods over which to average (can be a non-integer)
    NUM_AVERAGING_PERIODS= 4.0

There are three different options for the timescale.  Flow timescale is the length (from the Reynolds number) divide by freestream velocity.  Turb timescale is just the model timescale for SST or KE.  Max turb timescale is the maximum turbulent timescale in the simulation.

I've tested it on an unsteady cylinder, and it works like I expect it to. There's a few issues, but they seem to be issues with the averaging method itself, rather than the implementation.