### PR TITLE
Swap the resolved flow for average flow in hybrid

### DIFF
--- a/SU2_CFD/include/solver_structure.inl
+++ b/SU2_CFD/include/solver_structure.inl
@@ -942,11 +942,17 @@ inline unsigned long CSolver::GetPoint_Max_BGS(unsigned short val_var) { return 
 
 inline su2double* CSolver::GetPoint_Max_Coord_BGS(unsigned short val_var) { return Point_Max_Coord_BGS[val_var]; }
 
+// The loop should be over nPoints to guarantee that the boundaries are
+//  well updated
 inline void CSolver::Set_OldSolution(CGeometry *geometry) {
-  for (unsigned long iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++)
-    node[iPoint]->Set_OldSolution(); // The loop should be over nPoints
-                                     //  to guarantee that the boundaries are
-                                     //  well updated
+  for (unsigned long iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
+    node[iPoint]->Set_OldSolution();
+  }
+  if (average_node != NULL) {
+    for (unsigned long iPoint = 0; iPoint < geometry->GetnPoint(); iPoint++) {
+      average_node[iPoint]->Set_OldSolution();
+    }
+  }
 }
 
 inline void CSolver::Set_NewSolution(CGeometry *geometry) { }

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -3037,6 +3037,7 @@ void CSolver::InitAverages() {
   assert(average_node != NULL); // Check that the average nodes are set up
   for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
     average_node[iPoint]->SetSolution(node[iPoint]->GetSolution());
+    average_node[iPoint]->SetSolution_Old(node[iPoint]->GetSolution());
   }
 }
 


### PR DESCRIPTION
Since the turbulence functions are split between the base class and the derived classes, some of the functions were missed in the initial implementation.  The resolved flow variables were used in hybrid simulations, instead of the average flow variables.
