### PR TITLE
A few improvements to the hybrid model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ notifications:
 branches:
     only:
         - pecos-dev
-        - fix-travis-CI
+        - pecos-hybrid-fixes
 
 addons:
   apt:

--- a/SU2_CFD/include/hybrid_RANS_LES_forcing.hpp
+++ b/SU2_CFD/include/hybrid_RANS_LES_forcing.hpp
@@ -123,14 +123,14 @@ class CHybridForcingTG0 : public CHybridForcingAbstractBase{
    * \param[in]  Lmesh - Mesh length scales
    * \param[in]  D - Domain lengths in periodic directions
    * \param[in]  dwall - Distance to nearest wall
-   * \param[out] b - TG velocity at point.
+   * \param[out] h - TG velocity at point.
    */
   void SetTGField(const su2double* x, su2double Lsgs,
-                  const su2double* Lmesh, const su2double* D,
+                  const su2double* D,
                   su2double dwall, su2double* h) const;
 
   void SetAxiTGField(const su2double* x, const su2double Lsgs,
-		     const su2double* Lmesh, const su2double* D,
+		     const su2double* D,
 		     const su2double dwall, su2double* h) const;
 
 

--- a/SU2_CFD/include/hybrid_RANS_LES_forcing.inl
+++ b/SU2_CFD/include/hybrid_RANS_LES_forcing.inl
@@ -73,7 +73,7 @@ inline su2double CHybridForcingTG0::ComputeScalingFactor(
 
 inline void CHybridForcingTG0::SetTGField(
                 const su2double* x, const su2double Lsgs,
-                const su2double* Lmesh, const su2double* D,
+                const su2double* D,
                 const su2double dwall, su2double* h) const {
 
   //const su2double A = 1./3., B = -1.0, C = 2./3.;
@@ -82,13 +82,12 @@ inline void CHybridForcingTG0::SetTGField(
 
   for (unsigned int ii=0; ii<3; ii++) {
     const su2double ell = min(Lsgs, dwall);
-    const su2double elllim = max(ell, 2.0*Lmesh[ii]);
 
     if (D[ii] > 0.0) {
-      const su2double denom = round(D[ii]/min(elllim, D[ii]));
+      const su2double denom = round(D[ii]/min(ell, D[ii]));
       a[ii] = M_PI/(D[ii]/denom);
     } else {
-      a[ii] = M_PI/elllim;
+      a[ii] = M_PI/ell;
     }
   }
 
@@ -100,7 +99,7 @@ inline void CHybridForcingTG0::SetTGField(
 
 inline void CHybridForcingTG0::SetAxiTGField(
                 const su2double* x, const su2double Lsgs,
-                const su2double* Lmesh, const su2double* D,
+                const su2double* D,
                 const su2double dwall, su2double* h) const {
 
   // Convert incoming coords and lengths to cylindrical coords...
@@ -115,11 +114,6 @@ inline void CHybridForcingTG0::SetAxiTGField(
   Rsgs[1] = Lsgs; //cos(r[2])*Lsgs + sin(r[2])*Lsgs;
   Rsgs[2] = Lsgs/r[1]; //(-sin(r[2])*Lsgs + cos(r[2])*Lsgs)/r[1];
 
-  su2double Rmesh[3];
-  Rmesh[0] = Lmesh[0];
-  Rmesh[1] = sqrt(Lmesh[1]*Lmesh[1] + Lmesh[2]*Lmesh[2]); //cos(r[2])*Lmesh[1] + sin(r[2])*Lmesh[2];
-  Rmesh[2] = sqrt(Lmesh[1]*Lmesh[1] + Lmesh[2]*Lmesh[2])/r[1]; //(-sin(r[2])*Lmesh[1] + cos(r[2])*Lmesh[2])/r[1];
-
 
   // Set forcing velocity field in x,r,theta coords
 
@@ -130,13 +124,12 @@ inline void CHybridForcingTG0::SetAxiTGField(
   for (unsigned int ii=0; ii<3; ii++) {
     //const su2double ell = std::min(Rsgs[ii], dwall);
     const su2double ell = Rsgs[ii];
-    const su2double elllim = std::max(ell, 2.0*Rmesh[ii]);
 
     if (D[ii] > 0.0) {
-      const su2double denom = round(D[ii]/std::min(elllim, D[ii]));
+      const su2double denom = round(D[ii]/std::min(ell, D[ii]));
       a[ii] = M_PI/(D[ii]/denom);
     } else {
-      a[ii] = M_PI/elllim;
+      a[ii] = M_PI/ell;
     }
   }
 

--- a/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
@@ -156,23 +156,15 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     Tsgs = alpha * T_typical;
     Tsgs = max(Tsgs, T_kol);
 
-    // FIXME: I think this is equivalent to repo version of CDP,but
-    // not consistent with paper description, except for orthogonal
-    // grids aligned with coordinate axes.  Check with Sigfried.
-    const su2double* const* ResolutionTensor = geometry->node[iPoint]->GetResolutionTensor();
-    Lmesh[0] = ResolutionTensor[0][0];
-    Lmesh[1] = ResolutionTensor[1][1];
-    Lmesh[2] = ResolutionTensor[2][2];
-
     // Get dwall
     dwall = geometry->node[iPoint]->GetWall_Distance();
 
     if (config->isHybrid_Forced_Axi()) {
       // Angular periodic version 
-      this->SetAxiTGField(x, Lsgs, Lmesh, D, dwall, h);
+      this->SetAxiTGField(x, Lsgs, D, dwall, h);
     } else {
       // Compute TG velocity at this point
-      this->SetTGField(x, Lsgs, Lmesh, D, dwall, h);
+      this->SetTGField(x, Lsgs, D, dwall, h);
     }
 
     const su2double Ftar = this->GetTargetProduction(v2, Tsgs, alpha);

--- a/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
@@ -168,7 +168,7 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     dwall = geometry->node[iPoint]->GetWall_Distance();
 
     if (config->isHybrid_Forced_Axi()) {
-      // Angular periodic version 
+      // Angular periodic version
       this->SetAxiTGField(x, Lsgs, Lmesh, D, dwall, h);
     } else {
       // Compute TG velocity at this point

--- a/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
@@ -168,7 +168,7 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     dwall = geometry->node[iPoint]->GetWall_Distance();
 
     if (config->isHybrid_Forced_Axi()) {
-      // Angular periodic version
+      // Angular periodic version 
       this->SetAxiTGField(x, Lsgs, Lmesh, D, dwall, h);
     } else {
       // Compute TG velocity at this point

--- a/SU2_CFD/src/hybrid_RANS_LES_model.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_model.cpp
@@ -185,8 +185,6 @@ void CHybrid_Mediator::ComputeResolutionAdequacy(const CGeometry* geometry,
 
   /*--- Find eigenvalues and eigenvecs for grid-based resolution tensor ---*/
   const su2double* const* ResolutionTensor = geometry->node[iPoint]->GetResolutionTensor();
-  const su2double* ResolutionValues = geometry->node[iPoint]->GetResolutionValues();
-  const su2double* const* ResolutionVectors = geometry->node[iPoint]->GetResolutionVectors();
 
   // Compute inverse length scale tensor
   const su2double alpha =
@@ -209,6 +207,28 @@ void CHybrid_Mediator::ComputeResolutionAdequacy(const CGeometry* geometry,
     }
   }
 
+  // cout << "Inverse length tensor" << endl;
+  //cout << "[";
+  //for (iDim = 0; iDim < nDim; iDim++) {
+  //  cout << "[";
+  //  for (jDim = 0; jDim < nDim; jDim++) {
+  //    cout << invLengthTensor[iDim][jDim];
+  //    if (jDim != nDim-1) cout << ",\t";
+  //  }
+  //  cout << "]" << endl;
+  //}
+  //cout << "Metric tensor" << endl;
+  //cout << "[";
+  //for (iDim = 0; iDim < nDim; iDim++) {
+  //  cout << "[";
+  //  for (jDim = 0; jDim < nDim; jDim++) {
+  //    cout << ResolutionTensor[iDim][jDim];
+  //    if (jDim != nDim-1) cout << ",\t";
+  //  }
+  //  cout << "]" << endl;
+  //  if (iDim != nDim-1) cout << " ";
+  //}
+
   su2double LinvM[3][3];
   su2double frobenius_norm = 0;
   for (iDim = 0; iDim < nDim; iDim++) {
@@ -225,6 +245,13 @@ void CHybrid_Mediator::ComputeResolutionAdequacy(const CGeometry* geometry,
     const su2double C_r = 1.0;
     const su2double r_k_min = 1.0E-8;
     const su2double r_k_max = 30;
+    const su2double diff = frobenius_norm - max_eigval;
+    cout << "Frobenius norm - spectral norm:\t" << diff << "\t";
+    cout << "Relative diff:\t" << diff/max_eigval << endl;
+    if ((max_eigval > 1E-16) &&
+        ((max_eigval - frobenius_norm) > 1E-8*max_eigval)) {
+      SU2_MPI::Error("Frobenius norm exceeded the max eigenvalue!", CURRENT_FUNCTION);
+    }
     r_k = C_r*min(max_eigval, frobenius_norm);
     r_k = max(min(r_k, r_k_max), r_k_min);
 

--- a/SU2_CFD/src/numerics_direct_mean_hybrid.cpp
+++ b/SU2_CFD/src/numerics_direct_mean_hybrid.cpp
@@ -412,11 +412,33 @@ void CAvgGrad_Hybrid::AddSGSHeatFlux(su2double **val_gradprimvar,
 void CAvgGrad_Hybrid::AddSGS_TKE_Diffusion(const su2double * const* val_gradturbvar,
                                            const su2double val_alpha,
                                            const su2double val_eddy_viscosity) {
- const su2double alpha_fac = val_alpha*(2.0 - val_alpha);
+ /*--- XXX: Figure out what to do with this term in hybrid.
+  *
+  * The limits are clear.  In RANS, it should be (mu + mu_t/sigma_k) dk/dx
+  * In DNS, it should go to zero.  But the intermediate scaling is
+  * not clear.  How do the modeled terms (molecular diffusion and
+  * turbulent transport) scale with alpha?
+  *
+  * It is also debateable how important these choices are.  Wilcox argues
+  * that these terms are only important in hypersonic flows.
+  *
+  * Several possibilities:
+  * 1. Scale with alpha.  Simplest and easiest.
+  * 2. The gradient should be w.r.t. (alpha k), or k_{modeled}. This
+  *    may be better, but does mean that sharp gradients in alpha will
+  *    produce high diffusion, even if alpha ~= 0.  Is this the
+  *    desired behavior? Does it present numerical difficulties?
+  * 3. Scale mu_T with alpha, as done for the stress. This is not a
+  *    complete solution in and of itself, since the (mu * dk/dx) term
+  *    should also vanish in the limit of alpha -> 0. But it could
+  *    be combined with the other two approaches.
+  *
+  * Choice 1 is taken for now.
+  * ---*/
  const su2double sigma_k = 1.0;
- const su2double diffusivity = alpha_fac*val_eddy_viscosity/sigma_k;
+ const su2double diffusivity = val_alpha * val_eddy_viscosity/sigma_k;
  for (unsigned short iDim = 0; iDim < nDim; iDim++) {
-    TKE_diffusion[iDim] += diffusivity * val_gradturbvar[0][iDim];
+    TKE_diffusion[iDim] += diffusivity * val_alpha * val_gradturbvar[0][iDim];
   }
 }
 

--- a/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
@@ -44,6 +44,8 @@ CTurbKESolver::CTurbKESolver(void) : CTurbSolver() {
 
   /*--- Array initialization ---*/
   constants = NULL;
+  SlidingState = NULL;
+  SlidingStateNodes = NULL;
 
 }
 

--- a/SU2_CFD/test/Makefile.am
+++ b/SU2_CFD/test/Makefile.am
@@ -84,8 +84,10 @@ test_driver_SOURCES = convective_blending_test.cpp \
                       viscous_residual_2d_test.cpp \
                       viscous_model_split.cpp \
                       averaging_timescale_test.cpp \
-		      resolution_adequacy.cpp \
 		      main.cpp
+if BUILD_LAPACK
+test_driver_SOURCES += resolution_adequacy.cpp
+endif
 endif
 
 # Tests to be run

--- a/SU2_CFD/test/Makefile.am
+++ b/SU2_CFD/test/Makefile.am
@@ -84,6 +84,7 @@ test_driver_SOURCES = convective_blending_test.cpp \
                       viscous_residual_2d_test.cpp \
                       viscous_model_split.cpp \
                       averaging_timescale_test.cpp \
+		      resolution_adequacy.cpp \
 		      main.cpp
 endif
 

--- a/SU2_CFD/test/forcing_test.cpp
+++ b/SU2_CFD/test/forcing_test.cpp
@@ -267,13 +267,12 @@ BOOST_FIXTURE_TEST_CASE(TaylorGreenFields, ForcingFixture) {
 
   su2double x[3] = {22.879600000000000, -1.2667139999999999, 3.5793299999999999E-003};
   su2double Lsgs = 0.64981218416406406;
-  su2double Lmesh[3] = {0.0634665, 0.0146755, 0.0785398};
   su2double D[3] = {M_PI, 0.25, 1.1780972451};
   su2double dwall = 0.171989;
   su2double h[3];
 
   CHybridForcingTG0 forcing(geometry, config);
-  forcing.SetTGField(x, Lsgs, Lmesh, D, dwall, h);
+  forcing.SetTGField(x, Lsgs, D, dwall, h);
 
   su2double true_h[3] = {-4.4539063719893331E-003,
                           0.012204205194536234,

--- a/SU2_CFD/test/meson.build
+++ b/SU2_CFD/test/meson.build
@@ -26,6 +26,7 @@ SU2_CFD_boost_tests = files(['convective_blending_test.cpp',
                              'viscous_residual_2d_test.cpp',
                              'viscous_model_split.cpp',
                              'averaging_timescale_test.cpp',
+                             'resolution_adequacy.cpp',
                              'main.cpp'])
 
 SU2_CFD_test_driver = executable('test_driver',

--- a/SU2_CFD/test/meson.build
+++ b/SU2_CFD/test/meson.build
@@ -26,8 +26,11 @@ SU2_CFD_boost_tests = files(['convective_blending_test.cpp',
                              'viscous_residual_2d_test.cpp',
                              'viscous_model_split.cpp',
                              'averaging_timescale_test.cpp',
-                             'resolution_adequacy.cpp',
                              'main.cpp'])
+
+if mkl_dep.found()
+  SU2_CFD_boost_tests += files(['resolution_adequacy.cpp'])
+endif
 
 SU2_CFD_test_driver = executable('test_driver',
                                  SU2_CFD_boost_tests,

--- a/SU2_CFD/test/resolution_adequacy.cpp
+++ b/SU2_CFD/test/resolution_adequacy.cpp
@@ -1,0 +1,258 @@
+/*!
+ * \file resolution_adequacy.cpp
+ * \brief Tests the resolution adequacy calculation
+ * \author C. Pederson
+ * \version 6.1.0 "Falcon"
+ *
+ * The current SU2 release has been coordinated by the
+ * SU2 International Developers Society <www.su2devsociety.org>
+ * with selected contributions from the open-source community.
+ *
+ * The main research teams contributing to the current release are:
+ *  - Prof. Juan J. Alonso's group at Stanford University.
+ *  - Prof. Piero Colonna's group at Delft University of Technology.
+ *  - Prof. Nicolas R. Gauger's group at Kaiserslautern University of Technology.
+ *  - Prof. Alberto Guardone's group at Polytechnic University of Milan.
+ *  - Prof. Rafael Palacios' group at Imperial College London.
+ *  - Prof. Vincent Terrapon's group at the University of Liege.
+ *  - Prof. Edwin van der Weide's group at the University of Twente.
+ *  - Lab. of New Concepts in Aeronautics at Tech. Institute of Aeronautics.
+ *
+ * Copyright 2012-2018, Francisco D. Palacios, Thomas D. Economon,
+ *                      Tim Albring, and the SU2 contributors.
+ *
+ * SU2 is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * SU2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with SU2. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <random>
+#include <limits> // used to find machine epsilon
+
+#include "../include/solver_structure.hpp"
+#include "../include/solver_structure_v2f.hpp"
+#include "../include/variable_structure_v2f.hpp"
+#include "../include/hybrid_RANS_LES_model.hpp"
+
+namespace resolution_adequacy_test {
+
+const unsigned short nDim = 3;
+const unsigned short nVar = nDim+2;
+const unsigned short nPrimVar = nDim+9;
+const unsigned short nSecVar = 4;
+
+/**
+ * Write a cfg file to be used in initializing the CConfig object.
+ */
+static void WriteCfgFile(const char* filename) {
+
+  std::ofstream cfg_file;
+
+  cfg_file.open(filename, ios::out);
+  cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
+  cfg_file << "HYBRID_RANSLES= MODEL_SPLIT" << std::endl;
+  cfg_file << "RUNTIME_AVERAGING= POINTWISE" << std::endl;
+  cfg_file << "UNSTEADY_SIMULATION= TIME_STEPPING" << std::endl;
+  cfg_file << "KIND_TURB_MODEL= KE" << std::endl;
+  cfg_file.close();
+
+}
+
+class CTestGeometry : public CGeometry {
+ public:
+  CTestGeometry(CConfig* config) : CGeometry() {
+    nPoint = 1;
+    /*--- Local scope overrides file scope ---*/
+    nDim = resolution_adequacy_test::nDim;
+
+    node = new CPoint*[nPoint];
+    for (unsigned short iPoint = 0; iPoint < nPoint; iPoint++) {
+      node[iPoint] = new CPoint(0, 0, 0, iPoint, config);
+      node[iPoint]->SetVolume(1);
+      for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+        for (unsigned short jDim = 0; jDim < nDim; jDim++) {
+          node[iPoint]->SetResolutionTensor(iDim, jDim, (iDim == jDim));
+        }
+      }
+    }
+  }
+};
+
+class CTestFlowSolver : public CNSSolver {
+ public:
+  CTestFlowSolver(unsigned short val_nDim, unsigned short val_nVar,
+                  CConfig* config)
+       : CNSSolver() {
+
+    nDim = val_nDim;
+    nVar = val_nVar;
+    nPoint = 1;
+    nPointDomain = 1;
+
+    Solution = new su2double[val_nVar];
+
+    node = new CVariable*[nPoint];
+    average_node = new CVariable*[nPoint];
+
+    const su2double density = 1.0;
+    const su2double laminar_viscosity = 1.0;
+    su2double* velocity = new su2double[nDim];
+    for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+      velocity[iDim] = 0;
+    }
+
+    node[0] = new CNSVariable(density, velocity, 0, nDim, nVar, config);
+    average_node[0] =
+        new CNSVariable(density, velocity, 0, nDim, nVar, config);
+
+    node[0]->SetLaminarViscosity(laminar_viscosity);
+    average_node[0]->SetLaminarViscosity(laminar_viscosity);
+    average_node[0]->SetKineticEnergyRatio(1.0);
+
+    /*--- Due to density, dUdy is entry [1, 1] (not [0, 1]) ---*/
+    node[0]->AddGradient_Primitive(1, 1, 1.0);
+    average_node[0]->AddGradient_Primitive(1, 1, 1.0);
+
+    delete [] velocity;
+  };
+};
+
+class CTestTurbSolver : public CTurbKESolver {
+ public:
+  CTestTurbSolver(su2double kine, su2double epsi, su2double v2,
+                  unsigned short val_nDim, CConfig* config)
+       : CTurbKESolver() {
+
+    nDim = val_nDim;
+    nVar = 4;
+    nPoint = 1;
+    nPointDomain = 1;
+
+    Solution = new su2double[nVar];
+
+    node = new CVariable*[nPoint];
+
+    const su2double f = 1;
+    const su2double muT = 1;
+    const su2double Tm = 1;
+    const su2double Lm = 1;
+
+    node[0] = new CTurbKEVariable(kine, epsi, v2, f, muT, Tm, Lm,
+                                  nDim, nVar, config);
+  };
+};
+
+BOOST_AUTO_TEST_SUITE(ResolutionAdequacy);
+
+/**
+ */
+BOOST_AUTO_TEST_CASE(FrobeniusNormNeverEntered) {
+
+  /*--- Setup ---*/
+
+  char cfg_filename[100] = "averaging_timescale_test.cfg";
+  WriteCfgFile(cfg_filename);
+  const unsigned short iZone = 0;
+  const unsigned short nZone = 1;
+  CConfig* config = new CConfig(cfg_filename, SU2_CFD, iZone, nZone, 2, VERB_NONE);
+  std::remove(cfg_filename);
+
+  CGeometry* geometry = new CTestGeometry(config);
+
+  CSolver** solver_container = new CSolver*[TURB_SOL+1];
+  solver_container[FLOW_SOL] =
+        new CTestFlowSolver(nDim, nVar, config);
+
+  const su2double kine = 3.0;
+  const su2double epsi = 1.0;
+  const su2double v2 = 2.0;
+  solver_container[TURB_SOL] =
+        new CTestTurbSolver(kine, epsi, v2, nDim, config);
+
+  /*--- Test --*/
+  CHybrid_Mediator mediator(nDim, config);
+  const unsigned short iPoint = 0;
+
+  su2double** J = new su2double*[nDim];
+  su2double** M = new su2double*[nDim];
+  for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+    J[iDim] = new su2double[nDim];
+    M[iDim] = new su2double[nDim];
+  }
+
+  const unsigned int seed = 42;
+  std::default_random_engine generator(seed);
+  std::uniform_real_distribution<su2double> dist(0.0, 1.0);
+  for (unsigned short i=0; i < 5000; i++) {
+    /*--- Create a random strain matrix ---*/
+    for (unsigned short iVar = 0; iVar < 5; iVar++) {
+      solver_container[FLOW_SOL]->node[0]->SetGradient_PrimitiveZero(iVar);
+      solver_container[FLOW_SOL]->average_node[0]->SetGradient_PrimitiveZero(iVar);
+    }
+    for (unsigned short iDim=0; iDim < nDim; iDim++) {
+      const unsigned short u_index = (iDim % 3);
+      /*--- Add +1 so that we get du/dy, dv/dz, and dw/dx ---*/
+      const unsigned short x_index = ((iDim+1) % 3);
+      const su2double grad_val = dist(generator);
+      solver_container[FLOW_SOL]->node[0]->AddGradient_Primitive(u_index+1, x_index, grad_val);
+      solver_container[FLOW_SOL]->average_node[0]->AddGradient_Primitive(u_index+1, x_index, grad_val);
+    }
+
+    /*--- Create a random symmetric positive-definite metric tensor ---*/
+    for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+      for (unsigned short jDim = 0; jDim < nDim; jDim++) {
+        J[iDim][jDim] = dist(generator);
+      }
+    }
+    for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+      for (unsigned short jDim = 0; jDim < nDim; jDim++) {
+        M[iDim][jDim] = 0.0;
+        for (unsigned short kDim = 0; kDim < nDim; kDim++) {
+          M[iDim][jDim] += J[iDim][kDim]*J[jDim][kDim];
+        }
+      }
+    }
+    // Since each entry is < 1 by construction, we can ensure
+    // that the matrix is positive definite by adding 1 to the diagonal
+    for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+      M[iDim][iDim] += 1;
+    }
+
+    for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+      for (unsigned short jDim = 0; jDim < nDim; jDim++) {
+        geometry->node[iPoint]->SetResolutionTensor(iDim, jDim, M[iDim][jDim]);
+      }
+    }
+
+    mediator.ComputeResolutionAdequacy(geometry, solver_container, iPoint);
+  }
+
+  /*--- Teardown ---*/
+  for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+    delete [] J[iDim];
+    delete [] M[iDim];
+  }
+  delete [] J;
+  delete [] M;
+
+  delete solver_container[0];
+  delete [] solver_container;
+  delete geometry;
+
+}
+
+BOOST_AUTO_TEST_SUITE_END();
+
+} // end namespace


### PR DESCRIPTION
Here's a few improvements to the hybrid model:

1. Change the scaling on the TKE diffusion term that models the unresolved molecular and turbulent transport. How this scales with alpha is an open question, but scaling with alpha is a good first guess.  This way, the TKE diffusion term turns off for DNS resolution.
2. Remove the Frobenius norm limit from the resolution adequacy eigenvalue calculation.  Since the Frobenius norm is always greater than or equal to the spectral norm, theoretically this limit should never be used.  I ran a test with random matrices, and the limit was never enforced in the 1000s of random matrices I used.  So given that both theoretically and practically this limit was never used, I'm throwing it out.
3. Remove the resolution length scale from the forcing length-scale calculation, as per our discussion with Sigfried.

[The results](https://github.com/clarkpede/SU2-regression-tests/blob/master/channel_HM/ValidationResults_channel_HM.ipynb) look good.  There's some differences, but neither the old nor the new state look "wrong."