### PR TITLE
Distinguish between alpha and beta

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -564,6 +564,7 @@ private:
   su2double Hybrid_Forcing_Strength,  /*!< \brief An overall scaling coefficient for the periodic forcing .*/
             Hybrid_Forcing_Vortex_Length;  /*!< \brief The forcing vortices will be of period N*L, where N is the forcing length and L is the turbulent lengthscale. */
   unsigned short Kind_Hybrid_SGET_Model; /*!< \brief Subgrid energy-transfer (SGET) model for hybrid RANS/LES models. */
+  bool Use_SGET_Overresolution_Fix; /*!< \brief Increase subgrid energy dissipation when over-resolved for hybrid RANS/LES models. */
   bool Use_Resolved_Turb_Stress; /*!< \brief Use the resolved turbulent stress during restarts. */
   unsigned short Kind_SGS_Model;                        /*!< \brief LES SGS model definition. */
   su2double* FluctStress_AR_Params; /*!< \brief The parameters defining the blending function applied to the fluctuating stress in high-AR cells. */
@@ -4410,6 +4411,13 @@ public:
    * \return Kind of SGET model
    */
   unsigned short GetKind_Hybrid_SGET_Model(void);
+
+  /*!
+   * \brief Check if the SGET model should increase dissipation in regions
+   *        of over-resolution.
+   * \return True if the SGET model should add an over-resolution fix.
+   */
+  bool GetUse_SGET_Overresolution_Fix(void) const { return Use_SGET_Overresolution_Fix; }
 
   /*!
    * \brief Check if the full resolved turbulent stress is to be used for

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -808,10 +808,13 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   addDoubleOption("HYBRID_FORCING_STRENGTH", Hybrid_Forcing_Strength, 8);
 
   /*!\brief HYBRID_FORCING_VORTEX_LENGTH  \n DESCRIPTION: The forcing vortices will be of period N*L, where N is the forcing length and L is the turbulent lengthscale. \ingroup Config*/
-  addDoubleOption("HYBRID_FORCING_VORTEX_LENGTH", Hybrid_Forcing_Vortex_Length, 4);
+  addDoubleOption("HYBRID_FORCING_VORTEX_LENGTH", Hybrid_Forcing_Vortex_Length, 8);
 
   /*! \brief SUBGRID_ENERGY_TRANSFER_MODEL \n DESCRIPTION: Specify the subgrid energy transfer model to be used with the model-split hybrid RANS/LES model. \n Options: see \link Hybrid_SGET_Model_Map \endlink \n DEFAULT: M43 \ingroup Config */
   addEnumOption("SUBGRID_ENERGY_TRANSFER_MODEL", Kind_Hybrid_SGET_Model, SGET_Model_Map, M43_MODEL);
+
+  /*!\brief USE_SGET_OVERRESOLUTION_FIX \n DESCRIPTION: Increase subgrid dissipation where the simulation is locally over-resolved. */
+  addBoolOption("USE_SGET_OVERRESOLUTION_FIX", Use_SGET_Overresolution_Fix, YES);
 
   /*!\brief USE_RESOLVED_TURB_STRESS \n DESCRIPTION: Use the resolved turbulent stress in stead of improved production for hybrid RANS/LES calculations. \ingroup Config*/
   addBoolOption("USE_RESOLVED_TURB_STRESS", Use_Resolved_Turb_Stress, YES);

--- a/SU2_CFD/include/hybrid_RANS_LES_forcing.hpp
+++ b/SU2_CFD/include/hybrid_RANS_LES_forcing.hpp
@@ -136,12 +136,11 @@ class CHybridForcingTG0 : public CHybridForcingAbstractBase{
 
   su2double GetTargetProduction(su2double v2,
                                 su2double T,
-                                su2double alpha) const;
+                                su2double beta) const;
 
-  su2double ComputeScalingFactor(su2double Ftar,
-                                 su2double resolution_adequacy,
-                                 su2double alpha,
-                                 su2double alpha_kol,
+  su2double ComputeScalingFactor(su2double resolution_adequacy,
+                                 su2double beta,
+                                 su2double beta_kol,
                                  su2double PFtest) const;
 
   void ComputeForcingField(CSolver** solver, CGeometry *geometry,

--- a/SU2_CFD/include/hybrid_RANS_LES_forcing.inl
+++ b/SU2_CFD/include/hybrid_RANS_LES_forcing.inl
@@ -40,8 +40,8 @@ inline su2double CHybridForcingAbstractBase::TransformCoords(
 
 inline su2double CHybridForcingTG0::GetTargetProduction(const su2double v2,
                                                         const su2double Tsgs,
-                                                        const su2double alpha) const {
-  return C_F * sqrt(alpha*v2)/Tsgs;
+                                                        const su2double beta) const {
+  return C_F * sqrt(beta*v2)/Tsgs;
 }
 
 inline const su2double* CHybridForcingTG0::GetForcingVector(unsigned long iPoint) const {

--- a/SU2_CFD/include/numerics_direct_mean_hybrid.hpp
+++ b/SU2_CFD/include/numerics_direct_mean_hybrid.hpp
@@ -60,7 +60,7 @@ private:
   su2double* PrimVar_Average_j; /*!< \brief The primitive variables, computed from average flow variables */
   su2double **Aniso_Eddy_Viscosity_i, **Aniso_Eddy_Viscosity_j; /*!< \brief The anisotropic eddy viscosity from the energy transfer model. */
   su2double **PrimVar_Grad_Average_i, **PrimVar_Grad_Average_j; /*!< \brief The gradient of the primitve variables from the average flow */
-  su2double alpha_i, alpha_j; /*!< \brief The kinetic energy ratio (of modeled to total turbulent kinetic energy) */
+  su2double beta_i, beta_j; /*!< \brief The kinetic energy ratio (of modeled to total turbulent kinetic energy) */
 
 public:
 
@@ -122,11 +122,11 @@ public:
    * the heat flux vector.
    *
    * \param[in] val_gradprimvar - The gradient of the average primitive variables
-   * \param[in] val_alpha - The ratio of modeled to total turbulent kinetic energy
+   * \param[in] val_beta - The ratio of modeled to total turbulent kinetic energy
    * \param[in] val_eddy_viscosity - The average (i.e. RANS) eddy viscosity
    */
   void AddSGSHeatFlux(su2double **val_gradprimvar,
-                      const su2double val_alpha,
+                      const su2double val_beta,
                       const su2double val_eddy_viscosity);
 
   /*!
@@ -149,7 +149,8 @@ public:
    *     turbulence variables.
    * \param[in] val_laminar_viscosity - Value of the laminar viscosity.
    */
-  void SetLaminar_TKE_Diffusion(const su2double* const *val_gradturbvar,
+  void SetLaminar_TKE_Diffusion(const su2double *const *val_gradturbvar,
+                                su2double val_beta,
                                 su2double val_laminar_viscosity);
 
   /*!
@@ -157,11 +158,11 @@ public:
    *
    * \param[in] val_gradturbvar - Mean value of the gradient of the
    *     turbulence variables.
-   * \param[in] val_alpha - Ratio of turbulent kinetic energy
+   * \param[in] val_beta - Ratio of turbulent kinetic energy
    * \param[in] val_eddy_viscosity - Value of the eddy viscosity.
    */
   void AddSGS_TKE_Diffusion(const su2double* const *val_gradturbvar,
-                            su2double val_alpha,
+                            su2double val_beta,
                             su2double val_eddy_viscosity);
 
   /*!
@@ -180,15 +181,15 @@ public:
    *
    * \param[in] val_primvar - The average primitive variables
    * \param[in] val_gradprimvar - The gradient of the average primitive variables
-   * \param[in] val_alpha - The ratio of modeled to total turbulent kinetic energy
+   * \param[in] val_beta - The ratio of modeled to total turbulent kinetic energy
    * \param[in] val_turb_ke - The total (not subfilter) turbulent kinetic energy
    * \param[in] val_eddy_viscosity - The average (i.e. RANS) eddy viscosity
    */
   void AddTauSGS(const su2double *val_primvar,
                  su2double **val_gradprimvar,
-                 const su2double val_alpha,
-                 const su2double val_turb_ke,
-                 const su2double val_eddy_viscosity);
+                 su2double val_beta,
+                 su2double val_turb_ke,
+                 su2double val_eddy_viscosity);
 
   /*!
    * \brief Add the stress tensor from the energy transfer model to the
@@ -247,11 +248,11 @@ public:
 
   /*!
    * \brief Set the ratio of modeled to total turbulent kinetic energy
-   * \param[in] val_alpha_i - The kinetic energy ratio at point i
-   * \param[in] val_alpha_j - The kinetic energy ratio at point j
+   * \param[in] val_beta_i- The kinetic energy ratio at point i
+   * \param[in] val_beta_j - The kinetic energy ratio at point j
    */
-  void SetKineticEnergyRatio(const su2double val_alpha_i,
-                             const su2double val_alpha_j);
+  void SetKineticEnergyRatio(su2double val_beta_i,
+                             su2double val_beta_j);
 };
 
 #include "numerics_direct_mean_hybrid.inl"

--- a/SU2_CFD/include/numerics_direct_mean_hybrid.inl
+++ b/SU2_CFD/include/numerics_direct_mean_hybrid.inl
@@ -54,8 +54,8 @@ inline void CAvgGrad_Hybrid::SetPrimVarGradient_Average(su2double **val_primvar_
   PrimVar_Grad_Average_j = val_primvar_grad_j;
 }
 
-inline void CAvgGrad_Hybrid::SetKineticEnergyRatio(const su2double val_alpha_i,
-                                                   const su2double val_alpha_j) {
-  alpha_i = val_alpha_i;
-  alpha_j = val_alpha_j;
+inline void CAvgGrad_Hybrid::SetKineticEnergyRatio(const su2double val_beta_i,
+                                                   const su2double val_beta_j) {
+  beta_i = val_beta_i;
+  beta_j = val_beta_j;
 }

--- a/SU2_CFD/include/numerics_structure.hpp
+++ b/SU2_CFD/include/numerics_structure.hpp
@@ -589,9 +589,9 @@ public:
 
   /*!
    * \brief Set the ratio of modeled to total turbulent kinetic energy
-   * \param[in] val_alpha - The turbulent kinetic energy ratio
+   * \param[in] val_beta - The turbulent kinetic energy ratio
    */
-  void SetKineticEnergyRatio(su2double val_alpha);
+  void SetKineticEnergyRatio(su2double val_beta);
 
   /*!
    * \brief Set the turbulent kinetic energy.

--- a/SU2_CFD/include/numerics_structure.inl
+++ b/SU2_CFD/include/numerics_structure.inl
@@ -329,8 +329,8 @@ inline void CNumerics::SetResolutionAdequacy(su2double val_r_k) { Resolution_Ade
 
 inline void CNumerics::SetResolvedTurbStress(su2double** val_turb_stress) { }
 
-inline void CNumerics::SetKineticEnergyRatio(su2double val_alpha) {
-  KineticEnergyRatio = val_alpha;
+inline void CNumerics::SetKineticEnergyRatio(su2double val_beta) {
+  KineticEnergyRatio = val_beta;
 }
 
 inline void CNumerics::SetIntermittency(su2double intermittency_in) { }

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -155,7 +155,7 @@ protected:
    * This step roughly corresponds to:
    *   // Retrieve U_current
    *   // Retrieve U_average
-   *   dU = (U_current - U_average)*weight;
+   *   dU = (U_current - U_average)*(dt/(dt + averaging_period));
    *   // Store dU
    *
    * Note that the base class (CSolver) updates the average of the solution.
@@ -166,7 +166,7 @@ protected:
    * function if you intend to keep the solution variables. Include
    * this line:
    * \code
-   *   CSolver::UpdateAverage(weight, iPoint, buffer, config);
+   *   CSolver::UpdateAverage(dt, averaging_period, iPoint, buffer, config);
    * \endcode
    *
    * \param[in] weight - The amount to weight the update on the average
@@ -174,7 +174,8 @@ protected:
    * \param[inout] buffer - An allocated array of size nVar for working calculations
    * \param[in] config - Definition of the particular problem.
    */
-  virtual void UpdateAverage(su2double weight,
+  virtual void UpdateAverage(su2double dt,
+                             su2double averaging_period,
                              unsigned long iPoint,
                              su2double* buffer,
                              const CConfig* config);
@@ -9278,10 +9279,11 @@ public:
    * \param buffer - An allocated array of size nVar for working calculations
    * \param[in] config - Definition of the particular problem.
    */
-  void UpdateAverage(su2double weight,
+  void UpdateAverage(su2double dt,
+                     su2double averaging_period,
                      unsigned long iPoint,
                      su2double* buffer,
-                     const CConfig* config);
+                     const CConfig* config) override;
 
   /*!
    * \brief Initialize the extra quantities associated with averages.

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -1277,9 +1277,9 @@ public:
 
   /*!
    * \brief Set the ratio of modeled to total turbulent kinetic energy.
-   * \param[in] val_alpha - The ratio of modeled to total turbulent kinetic energy.
+   * \param[in] val_beta - The ratio of modeled to total turbulent kinetic energy.
    */
-  virtual void SetKineticEnergyRatio(su2double val_alpha);
+  virtual void SetKineticEnergyRatio(su2double val_beta);
 
   /*!
    * \brief Add to the value of the resolved turbulent stress.
@@ -4155,9 +4155,9 @@ public:
 
   /*!
    * \brief Set the ratio of modeled to total turbulent kinetic energy.
-   * \param val_alpha -  The ratio of modeled to total turbulent kinetic energy.
+   * \param val_beta -  The ratio of modeled to total turbulent kinetic energy.
    */
-  void SetKineticEnergyRatio(su2double val_alpha);
+  void SetKineticEnergyRatio(su2double val_beta) override;
 
   /*!
    * \brief Add to the value of the resolved turbulent stress.
@@ -4239,7 +4239,7 @@ public:
    * \brief Get the ratio of modeled to total turbulent kinetic energy.
    * \return The ratio of modeled to total turbulent kinetic energy.
    */
-  su2double GetKineticEnergyRatio(void) const;
+  su2double GetKineticEnergyRatio(void) const override;
 
   /*!
    * \brief Get a component of the resolved turbulent stress.

--- a/SU2_CFD/include/variable_structure.inl
+++ b/SU2_CFD/include/variable_structure.inl
@@ -516,7 +516,7 @@ inline void CVariable::SetForcingFactor(su2double factor) { }
 
 inline void CVariable::SetForcingClipping(su2double clipping) { }
 
-inline void CVariable::SetKineticEnergyRatio(su2double val_alpha) { }
+inline void CVariable::SetKineticEnergyRatio(su2double val_beta) { }
 
 inline void CVariable::AddResolvedTurbStress(unsigned short iDim,
                                                unsigned short jDim,
@@ -1080,8 +1080,8 @@ inline void CNSVariable::SetAnisoEddyViscosity(su2double** aniso_eddy_visc) {
   }
 }
 
-inline void CNSVariable::SetKineticEnergyRatio(const su2double val_alpha) {
-  KineticEnergyRatio = val_alpha;
+inline void CNSVariable::SetKineticEnergyRatio(const su2double val_beta) {
+  KineticEnergyRatio = val_beta;
 }
 
 inline void CNSVariable::AddResolvedTurbStress(unsigned short iDim,

--- a/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
@@ -138,8 +138,9 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     const su2double v2 = max(solver[TURB_SOL]->node[iPoint]->GetSolution(2), V2_MIN);
 
     // ratio of modeled to total TKE
-    su2double alpha = solver[FLOW_SOL]->average_node[iPoint]->GetKineticEnergyRatio();
-    alpha = max(alpha, 1e-8);
+    const su2double beta = solver[FLOW_SOL]->average_node[iPoint]->GetKineticEnergyRatio();
+    // ratio of subfilter to total TKE
+    const su2double alpha = max(pow(alpha, 1.7), 1e-8);
 
     // average of r_M
     const su2double resolution_adequacy =

--- a/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
@@ -140,7 +140,7 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     // ratio of modeled to total TKE
     const su2double beta = solver[FLOW_SOL]->average_node[iPoint]->GetKineticEnergyRatio();
     // ratio of subfilter to total TKE
-    const su2double alpha = max(pow(alpha, 1.7), 1e-8);
+    const su2double alpha = max(pow(beta, 1.7), 1e-8);
 
     // average of r_M
     const su2double resolution_adequacy =

--- a/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_forcing.cpp
@@ -139,8 +139,6 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
 
     // ratio of modeled to total TKE
     const su2double beta = solver[FLOW_SOL]->average_node[iPoint]->GetKineticEnergyRatio();
-    // ratio of subfilter to total TKE
-    const su2double alpha = max(pow(beta, 1.7), 1e-8);
 
     // average of r_M
     const su2double resolution_adequacy =
@@ -155,9 +153,9 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     assert(T_typical >= 0);
     assert(T_kol > 0);
 
-    Lsgs = max(forcing_scale * pow(alpha, 1.5) * L_typical, L_kol);
+    Lsgs = max(forcing_scale * pow(beta, 1.5) * L_typical, L_kol);
     Lsgs = max(Lsgs, L_kol);
-    Tsgs = alpha * T_typical;
+    Tsgs = beta * T_typical;
     Tsgs = max(Tsgs, T_kol);
 
     // Get dwall
@@ -171,7 +169,7 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
       this->SetTGField(x, Lsgs, D, dwall, h);
     }
 
-    const su2double Ftar = this->GetTargetProduction(v2, Tsgs, alpha);
+    const su2double Ftar = this->GetTargetProduction(v2, Tsgs, beta);
 
     // Compute PFtest
     su2double PFtest = 0.0;
@@ -181,10 +179,10 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     }
     PFtest *= Ftar;
 
-    const su2double alpha_kol = solver[TURB_SOL]->node[iPoint]->GetKolKineticEnergyRatio();
+    const su2double beta_kol = solver[TURB_SOL]->node[iPoint]->GetKolKineticEnergyRatio();
 
-    const su2double eta = this->ComputeScalingFactor(Ftar, resolution_adequacy,
-                                                     alpha, alpha_kol, PFtest);
+    const su2double eta = this->ComputeScalingFactor(resolution_adequacy,
+                                                     beta, beta_kol, PFtest);
 
     /*--- Check for an unphysically large forcing ---*/
 
@@ -193,17 +191,17 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
     for (unsigned short iDim=0; iDim<nDim; iDim++) {
       energy_added += prim_vars[iDim+1]*h[iDim];
     }
-    energy_added *= delta_t * eta;
+    energy_added *= delta_t * eta * Ftar;
     su2double clipping = 1.0;
-    if (energy_added >= alpha*k_tot*0.1) {
-      /*--- Arbitrary constant of 0.99 added to prevent T=0 ---*/
-      clipping = alpha*k_tot/energy_added * 0.10;
+    if (energy_added >= beta*k_tot*0.99) {
+      /*--- Arbitrary constant of 0.99 added to prevent Temp=0 ---*/
+      clipping = beta*k_tot/energy_added * 0.99;
     }
 
 
     /*--- Store eta*h so we can compute the derivatives ---*/
     for (unsigned short iDim = 0; iDim < nDim; iDim++) {
-      node[iPoint][iDim] = clipping*eta*h[iDim];
+      node[iPoint][iDim] = clipping*Ftar*eta*h[iDim];
     }
 
     /*--- Save the forcing for output ---*/
@@ -216,23 +214,18 @@ void CHybridForcingTG0::ComputeForcingField(CSolver** solver, CGeometry *geometr
 }
 
 su2double CHybridForcingTG0::ComputeScalingFactor(
-                     const su2double Ftar,
                      const su2double resolution_adequacy,
-                     const su2double alpha,
-                     const su2double alpha_kol,
+                     const su2double beta,
+                     const su2double beta_kol,
                      const su2double PFtest) const {
 
   su2double eta = 0.0;
 
-  // TODO: Compare this with Sigfried's improved version once channel
-  // validation is successful.
-  if ( (PFtest >= 0.0) && (resolution_adequacy < 1.0) ) {
-    const su2double Sr = tanh(1.0 - 1.0/sqrt(resolution_adequacy));
-    if (alpha <= alpha_kol) {
-      eta = -Ftar * Sr * (alpha - alpha_kol);
-    } else {
-      eta = -Ftar * Sr;
-    }
+  if (PFtest >= 0.0) {
+    const su2double F_r = -tanh(1.0 - pow(min(resolution_adequacy, 1.0), -0.5));
+    const su2double beta_hat = (1.0 - beta)/max(1.0 - beta_kol, 0.01) - 1;
+    const su2double Dlim = F_r * (tanh(10*beta_hat)+1);
+    eta = F_r - Dlim;
   }
 
   // Check for NaNs in debug mode.

--- a/SU2_CFD/src/hybrid_RANS_LES_model.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_model.cpp
@@ -177,17 +177,19 @@ void CHybrid_Mediator::SetupResolvedFlowSolver(const CGeometry* geometry,
      * of the model for fully-developed channel flow problems.  It is
      * unclear how necessary it is more more complex problems. ---*/
 
-    // const su2double avg_resolution_adequacy =
-    //   solver_container[FLOW_SOL]->average_node[iPoint]->GetResolutionAdequacy();
-    // assert(avg_resolution_adequacy >= 0);
-    // assert(avg_resolution_adequacy == avg_resolution_adequacy);
-    // //const su2double factor = pow(min(avg_resolution_adequacy, 10.0), 4.0/3);
-    // const su2double factor = max(min(avg_resolution_adequacy, 10.0), 1.0);
-    // for (unsigned short iDim = 0; iDim < nDim; iDim++) {
-    //   for (unsigned short jDim = 0; jDim < nDim; jDim++) {
-    //      aniso_eddy_viscosity[iDim][jDim] *= factor;
-    //   }
-    // }
+    if (config->GetUse_SGET_Overresolution_Fix()) {
+      const su2double avg_rM =
+        solver_container[FLOW_SOL]->average_node[iPoint]->GetResolutionAdequacy();
+      assert(avg_rM >= 0);
+      assert(avg_rM == avg_rM);
+      //const su2double factor = pow(min(avg_resolution_adequacy, 10.0), 4.0/3);
+      const su2double factor = max(min(avg_rM*avg_rM, 30.0), 1.0);
+      for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+        for (unsigned short jDim = 0; jDim < nDim; jDim++) {
+          aniso_eddy_viscosity[iDim][jDim] *= factor;
+        }
+      }
+    }
 
     solver_container[FLOW_SOL]->node[iPoint]->SetAnisoEddyViscosity(aniso_eddy_viscosity);
 

--- a/SU2_CFD/src/hybrid_RANS_LES_model.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_model.cpp
@@ -374,14 +374,14 @@ void CHybrid_Mediator::ComputeInvLengthTensor(CVariable* flow_vars,
 
   const su2double ktot = max(turb_vars->GetSolution(0),1e-8);
 
-  // v2 here is *subgrid*, so must multiply by alpha
+  // v2 here is *subgrid*, so must multiply by beta
   // v2 is initialized at zero to keep compiler warnings happy
   su2double v2_sgs = 0;
   if (config->GetKind_Turb_Model() == KE) {
-    v2_sgs = alpha*max(turb_vars->GetSolution(2),1e-8);
+    v2_sgs = beta*max(turb_vars->GetSolution(2),1e-8);
   } else if (config->GetKind_Turb_Model() == SST) {
     // TODO: Change this to the an estimate of v2 through muT
-    v2_sgs = alpha*2.0*max(turb_vars->GetSolution(0),1e-8)/3.0;
+    v2_sgs = beta*2.0*max(turb_vars->GetSolution(0),1e-8)/3.0;
   } else {
     SU2_MPI::Error("The RDELTA resolution adequacy option is only implemented for KE and SST turbulence models!", CURRENT_FUNCTION);
   }

--- a/SU2_CFD/src/hybrid_RANS_LES_model.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_model.cpp
@@ -108,12 +108,12 @@ void CHybrid_Mediator::ComputeResolutionAdequacy(const CGeometry* geometry,
   const su2double* const* ResolutionTensor = geometry->node[iPoint]->GetResolutionTensor();
 
   // Compute inverse length scale tensor
-  const su2double alpha =
+  const su2double beta =
       solver_container[FLOW_SOL]->average_node[iPoint]->GetKineticEnergyRatio();
   ComputeInvLengthTensor(solver_container[FLOW_SOL]->node[iPoint],
                          solver_container[FLOW_SOL]->average_node[iPoint],
                          solver_container[TURB_SOL]->node[iPoint],
-                         alpha,
+                         beta,
                          config->GetKind_Hybrid_Resolution_Indicator());
 
   vector<su2double> eigvalues_iLM;
@@ -130,7 +130,7 @@ void CHybrid_Mediator::ComputeResolutionAdequacy(const CGeometry* geometry,
 
   const su2double C_r = 1.0;
   const su2double r_k_min = 1.0E-8;
-  const su2double r_k_max = (alpha > 1) ? 1.0 : 30;
+  const su2double r_k_max = (beta > 1) ? 1.0 : 30;
   const su2double r_k = max(min(C_r*max_eigval, r_k_max), r_k_min);
 
   // Set resolution adequacy in the CNSVariables class
@@ -250,20 +250,20 @@ void CHybrid_Mediator::SetupResolvedFlowNumerics(const CGeometry* geometry,
   su2double** aniso_viscosity_j =
       solver_container[FLOW_SOL]->node[jPoint]->GetAnisoEddyViscosity();
 
-  const su2double alpha_i =
+  const su2double beta_i =
       solver_container[FLOW_SOL]->average_node[iPoint]->GetKineticEnergyRatio();
-  const su2double alpha_j =
+  const su2double beta_j =
       solver_container[FLOW_SOL]->average_node[jPoint]->GetKineticEnergyRatio();
 
   numerics->SetAniso_Eddy_Viscosity(aniso_viscosity_i, aniso_viscosity_j);
-  numerics->SetKineticEnergyRatio(alpha_i, alpha_j);
+  numerics->SetKineticEnergyRatio(beta_i, beta_j);
 }
 
 
 void CHybrid_Mediator::ComputeInvLengthTensor(CVariable* flow_vars,
                                               CVariable* flow_avgs,
                                               CVariable* turb_vars,
-                                              const su2double val_alpha,
+                                              const su2double val_beta,
                                               const int short hybrid_res_ind) {
 
   unsigned short iDim, jDim, kDim;
@@ -291,7 +291,8 @@ void CHybrid_Mediator::ComputeInvLengthTensor(CVariable* flow_vars,
 
   const su2double rho =  flow_avgs->GetDensity();
 
-  su2double alpha = max(val_alpha, 1e-8);
+  const su2double beta = max(val_beta, 1E-8);
+  const su2double alpha = max(pow(val_beta, 1.7), 1E-8);
 
   // Get primative gradients
   su2double** val_gradprimvar =  flow_vars->GetGradient_Primitive();
@@ -386,11 +387,6 @@ void CHybrid_Mediator::ComputeInvLengthTensor(CVariable* flow_vars,
   // 2) tauSGRS contribution.  NB: Neglecting divergence contribution
   // here.  TODO: Add divergence contribution.
 
-  /*--- Testing on the WMH indicates that scaling the whole stress by
-   * alpha*(2-alpha) improves the model performance.  That change would
-   * make the turbulent kinetic energy inconsistent, so it is avoided here.
-   * But that indicates there's some other issue. ---*/
-
   su2double alpha_fac = alpha*(2.0 - alpha);
   alpha_fac = max(alpha_fac, 1e-8);
   alpha_fac = min(alpha_fac, 1.0);
@@ -423,7 +419,7 @@ void CHybrid_Mediator::ComputeInvLengthTensor(CVariable* flow_vars,
           Pij[iDim][jDim] += 2.0*alpha_fac*eddy_viscosity*Sd_avg[iDim][jDim]*div_vel/3.0;
         }
         // rho*k contribtuion
-	Pij[iDim][jDim] -= 2.0/3.0*alpha*rho*ktot *
+	Pij[iDim][jDim] -= 2.0/3.0*beta*rho*ktot *
             (Sd[iDim][jDim] + Om[iDim][jDim] + div_vel*delta[iDim][jDim]/3.0);
       }
     }
@@ -437,7 +433,7 @@ void CHybrid_Mediator::ComputeInvLengthTensor(CVariable* flow_vars,
           // Contribution from div of velocity is (intentionally) omitted
         }
         // rho*k contribtuion
-	Pij[iDim][jDim] -= 2.0*alpha*rho*ktot*(Sd[iDim][jDim]+Om[iDim][jDim])/3.0;
+	Pij[iDim][jDim] -= 2.0*beta*rho*ktot*(Sd[iDim][jDim]+Om[iDim][jDim])/3.0;
       }
     }
     break;
@@ -479,6 +475,7 @@ void CHybrid_Mediator::ComputeInvLengthTensor(CVariable* flow_vars,
   }
   if (found_nan) {
     std::cout << "alpha = " << alpha << std::endl;
+    std::cout << "beta  = " << beta << std::endl;
     std::cout << "alpha_fac = " << alpha_fac << std::endl;
     for (iDim = 0; iDim < nDim; iDim++) {
       for (jDim = 0; jDim < nDim; jDim++) {

--- a/SU2_CFD/src/numerics_direct_turbulent_v2f.cpp
+++ b/SU2_CFD/src/numerics_direct_turbulent_v2f.cpp
@@ -353,19 +353,20 @@ void CSourcePieceWise_TurbKE::ComputeResidual(su2double *val_residual,
 
   SGSProduction = muT*S*S;
   if (config->GetBoolDivU_inTKEProduction()) {
-    SGSProduction -= (2.0/3.0)*rho*tke*diverg;
+    SGSProduction -= TWO3*rho*tke*diverg;
   }
 
   /*--- If using a hybrid method, include resolved production ---*/
 
   if (config->GetKind_HybridRANSLES() == MODEL_SPLIT) {
     /*--- Limit alpha to protect from imbalance in k_model vs k_resolved. ---*/
-    if (KineticEnergyRatio >= 0  && KineticEnergyRatio < 1) {
-      const su2double alpha = KineticEnergyRatio;
+    if (KineticEnergyRatio >= 0 && KineticEnergyRatio < 1) {
+      // KineticEnergyRatio is beta
+      const su2double alpha = pow(KineticEnergyRatio, 1.7);
       const su2double alpha_fac = alpha*(2.0 - alpha);
       SGSProduction = alpha_fac*muT*S*S;
       if (config->GetBoolDivU_inTKEProduction()) {
-	SGSProduction -= 2.0/3.0*rho*alpha*tke*diverg;
+	SGSProduction -= TWO3*rho * KineticEnergyRatio * tke*diverg;
       }
 
       if (config->GetUse_Resolved_Turb_Stress()) {

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -484,7 +484,7 @@ void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
           (config[iZone]->GetKind_HybridRANSLES() == MODEL_SPLIT);
   
       if (model_split_hybrid) {
-        RegisterScalar("alpha", "<greek>a</greek>", FLOW_SOL,
+        RegisterScalar("beta", "beta", FLOW_SOL,
                        &CVariable::GetKineticEnergyRatio, iZone, true);
         RegisterScalar("k_res", "k<sub>res</sub>", FLOW_SOL,
                        &CVariable::GetResolvedKineticEnergy, iZone, true);

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -17783,19 +17783,18 @@ unsigned long CNSSolver::SetPrimitive_Variables(CSolver **solver_container, CCon
       assert(k_resolved >= 0);
 
       const su2double tke_lim = max(k_total, 1.0E-8);
-      //const su2double a_kol = 1.0E-2; // XXX: We should actually get the viscous limit here
-      const su2double a_kol = solver_container[TURB_SOL]->node[iPoint]->GetKolKineticEnergyRatio();
-      su2double alpha_set = max(min((tke_lim - k_resolved)/tke_lim, 1.0), a_kol);
+      const su2double beta_kol = solver_container[TURB_SOL]->node[iPoint]->GetKolKineticEnergyRatio();
+      su2double beta_set = max(min((tke_lim - k_resolved)/tke_lim, 1.0), beta_kol);
 
-      // protect against negative alpha, just in case
-      alpha_set = max(alpha_set, 0.0);
-      average_node[iPoint]->SetKineticEnergyRatio(alpha_set);
-      assert(alpha_set == alpha_set);  // alpha should not be NaN
+      // protect against negative beta, just in case
+      beta_set = max(beta_set, 0.0);
+      average_node[iPoint]->SetKineticEnergyRatio(beta_set);
+      assert(beta_set == beta_set);  // beta should not be NaN
     }
 
     su2double total_tke = 0.0;
     su2double modeled_tke = 0.0;
-    su2double alpha = 1.0;
+    su2double beta = 1.0;
     if (turb_model != NONE) {
       eddy_visc = solver_container[TURB_SOL]->node[iPoint]->GetmuT();
       if (tkeNeeded) {
@@ -17803,8 +17802,8 @@ unsigned long CNSSolver::SetPrimitive_Variables(CSolver **solver_container, CCon
         total_tke = max(total_tke, tke_min);
 
         if (model_split){
-          alpha = average_node[iPoint]->GetKineticEnergyRatio();
-          modeled_tke = max(alpha*total_tke, 0.0);
+          beta = average_node[iPoint]->GetKineticEnergyRatio();
+          modeled_tke = max(beta*total_tke, 0.0);
         } else {
           modeled_tke = total_tke;
         }
@@ -17827,7 +17826,7 @@ unsigned long CNSSolver::SetPrimitive_Variables(CSolver **solver_container, CCon
         std::cout << "  modeled_tke = " << modeled_tke << std::endl;
         std::cout << "  resolved ke = " << node[iPoint]->GetVelocity2() << std::endl;
         std::cout << "  total tke   = " << total_tke << std::endl;
-        std::cout << "  alpha       = " << alpha << std::endl;
+        std::cout << "  beta        = " << beta << std::endl;
     }
     node[iPoint]->SetSecondaryVar(FluidModel);
     bool RightAvg = true;
@@ -17837,7 +17836,7 @@ unsigned long CNSSolver::SetPrimitive_Variables(CSolver **solver_container, CCon
         std::cout << "Error Setting average primitive variables!" << std::endl;
         std::cout << "  resolved ke = " << average_node[iPoint]->GetVelocity2() << std::endl;
         std::cout << "  total tke   = " << total_tke << std::endl;
-        std::cout << "  alpha       = " << alpha << std::endl;
+        std::cout << "  beta = " << beta << std::endl;
       }
       // We don't need the secondary variables
     }
@@ -20120,7 +20119,7 @@ void CNSSolver::UpdateAverage(const su2double weight,
 
     }
 
-    /*--- We can't update alpha (the ratio of modeled to total turbulent
+    /*--- We can't update beta (the ratio of modeled to total turbulent
      * kinetic energy) here because we don't have access to the RANS solver
      * variables. ---*/
 

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -20017,15 +20017,20 @@ void CNSSolver::BC_Far_Field(CGeometry *geometry, CSolver **solver_container, CN
   
 }
 
-void CNSSolver::UpdateAverage(const su2double weight,
+void CNSSolver::UpdateAverage(const su2double dt,
+                              const su2double averaging_period,
                               const unsigned long iPoint,
                               su2double* buffer,
                               const CConfig* config) {
 
+  /*--- For forward Euler, w = dt/T
+   *   For backward Euler, w = dt/(T+dt) ---*/
+  const su2double weight = dt/(averaging_period + dt);
+
   assert(average_node != NULL);
 
   // Call base first, to update averages of conserved variables
-  CSolver::UpdateAverage(weight, iPoint, buffer, config);
+  CSolver::UpdateAverage(dt, averaging_period, iPoint, buffer, config);
 
   su2double* fluct_velocity = new su2double[nDim];
   su2double* mean_velocity  = new su2double[nDim];
@@ -20079,7 +20084,8 @@ void CNSSolver::UpdateAverage(const su2double weight,
       /*-- Give Pk a different averaging time than the rest of the terms ---*/
 
       const su2double Pk_relaxation = config->GetProduction_Relaxation();
-      const su2double new_Pk = production + (current_production - production)*weight*Pk_relaxation;
+      const su2double Pk_weight = dt/(dt + averaging_period/Pk_relaxation);
+      const su2double new_Pk = production + (current_production - production)*Pk_weight;
       average_node[iPoint]->SetProduction(new_Pk);
 
       /*--- Update resolved kinetic energy ---*/

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -3157,12 +3157,9 @@ void CSolver::SetAverages(CGeometry* geometry, CSolver** solver,
        * So we change the weight to make the averaging act as if
        * dt = (N_T*timescale)/min_number_samples ---*/
       const unsigned short min_number_samples = 5;
+      const su2double averaging_period = max(N_T * timescale, dt*min_number_samples);
 
-      /*--- For forward Euler, w = dt/T
-       *   For backward Euler, w = dt/(T+dt) ---*/
-      const su2double weight = min(dt/(N_T * timescale + dt), 1.0/min_number_samples);
-
-      UpdateAverage(weight, iPoint, buffer, config);
+      UpdateAverage(dt, averaging_period, iPoint, buffer, config);
     }
 
     delete [] buffer;
@@ -3178,8 +3175,14 @@ void CSolver::SetAverages(CGeometry* geometry, CSolver** solver,
 }
 
 
-void CSolver::UpdateAverage(const su2double weight, const unsigned long iPoint,
-                            su2double* buffer, const CConfig* config) {
+void CSolver::UpdateAverage(const su2double dt,
+                            const su2double averaging_period,
+                            const unsigned long iPoint,
+                            su2double* buffer,
+                            const CConfig* config) {
+  /*--- For forward Euler, w = dt/T
+   *   For backward Euler, w = dt/(T+dt) ---*/
+  const su2double weight = dt/(averaging_period + dt);
 
   assert(average_node != NULL);
   const su2double* average = average_node[iPoint]->GetSolution();

--- a/SU2_CFD/src/variable_direct_mean.cpp
+++ b/SU2_CFD/src/variable_direct_mean.cpp
@@ -953,7 +953,8 @@ su2double CNSVariable::GetReynoldsStress(unsigned short iDim, unsigned short jDi
    * here.  The 2/3 \rho k \delta_{ij} must be added to give the proper
    * normal stresses ---*/
 
-  const su2double alpha_fac = KineticEnergyRatio*(2.0 - KineticEnergyRatio);
+  const su2double alpha = pow(KineticEnergyRatio, 1.7);
+  const su2double alpha_fac = alpha*(2.0 - alpha);
   /*--- Primitive[nDim+6] is eddy viscosity.  Can't use GetEddyViscosity
    * due to const qualifiers ---*/
   const su2double mut_sgs = alpha_fac*Primitive[nDim+6];

--- a/SU2_CFD/test/forcing_test.cpp
+++ b/SU2_CFD/test/forcing_test.cpp
@@ -115,7 +115,7 @@ class TestAvgVariable : public CVariable {
     Primitive[2] = 0.00357933;
     Primitive[3] = -0.266714;
     ResolutionAdequacy = 0.8;
-    KineticEnergyRatio = pow(0.598898, 1.0/1.7);
+    KineticEnergyRatio = 0.598898;
   }
   ~TestAvgVariable() {
     delete [] Primitive;
@@ -247,17 +247,16 @@ BOOST_FIXTURE_TEST_CASE(ForcingTest, ForcingFixture) {
 BOOST_FIXTURE_TEST_CASE(ScalingCoefficient, ForcingFixture) {
 
   const su2double alpha = 0.598898;
-  const su2double Ftar = 49.324157965434289;
   const su2double resolution_adequacy = 0.8;
   const su2double alpha_kol = 1.9086085598731258E-002;
   const su2double PFtest = 3.8390135906329317E-004;
 
   CHybridForcingTG0 forcing(geometry, config);
   forcing.ComputeForcingField(solver, geometry, config);
-  const su2double eta = forcing.ComputeScalingFactor(Ftar, resolution_adequacy,
+  const su2double eta = forcing.ComputeScalingFactor(resolution_adequacy,
                                                      alpha, alpha_kol, PFtest);
 
-  const su2double true_eta = 5.7950398607929117;
+  const su2double true_eta = 0.11748715038893287;
   const su2double tolerance = 1E-4;
   BOOST_CHECK_CLOSE_FRACTION(eta, true_eta, tolerance);
 }

--- a/SU2_CFD/test/forcing_test.cpp
+++ b/SU2_CFD/test/forcing_test.cpp
@@ -115,7 +115,7 @@ class TestAvgVariable : public CVariable {
     Primitive[2] = 0.00357933;
     Primitive[3] = -0.266714;
     ResolutionAdequacy = 0.8;
-    KineticEnergyRatio = 0.598898;
+    KineticEnergyRatio = pow(0.598898, 1.0/1.7);
   }
   ~TestAvgVariable() {
     delete [] Primitive;

--- a/SU2_CFD/test/resolution_adequacy.cpp
+++ b/SU2_CFD/test/resolution_adequacy.cpp
@@ -218,7 +218,7 @@ BOOST_FIXTURE_TEST_CASE(MaxIsOneWhenAlphaGreaterThanOne, RkFixture) {
   }
 
   /*--- Set alpha to be an unrealistic value ---*/
-  flow_avgs->SetKineticEnergyRatio(1.1);
+  flow_avgs->SetKineticEnergyRatio(pow(1.1, 1.0/1.7));
 
   /*--- Test --*/
 
@@ -254,7 +254,7 @@ BOOST_FIXTURE_TEST_CASE(MaxIs30WhenAlphaLessThanOne, RkFixture) {
   }
 
   /*--- Set alpha to be a realistic value ---*/
-  flow_avgs->SetKineticEnergyRatio(0.5);
+  flow_avgs->SetKineticEnergyRatio(pow(0.5, 1.0/1.7));
 
   /*--- Test --*/
 
@@ -282,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(MinEnforcedWhenRkIsSmall, RkFixture) {
   }
 
   /*--- Set alpha to be a realistic value ---*/
-  flow_avgs->SetKineticEnergyRatio(0.5);
+  flow_avgs->SetKineticEnergyRatio(pow(0.5, 1.0/1.7));
 
   /*--- Test --*/
 
@@ -298,8 +298,6 @@ BOOST_FIXTURE_TEST_CASE(SimpleRkTest, RkFixture) {
 
   /*--- Setup ---*/
 
-  /*--- To force rk to be very small, leave dUdy as 0 ---*/
-  /*--- Ensure isotropic contribution is zero --*/
   const unsigned short iPoint = 0;
   flow_vars->AddGradient_Primitive(1, 1, 1.0);
   flow_avgs->AddGradient_Primitive(1, 1, 1.0);
@@ -311,10 +309,11 @@ BOOST_FIXTURE_TEST_CASE(SimpleRkTest, RkFixture) {
   }
 
   /*--- Set v2 to 4/3 make (3/2*alpha*v2)^(1.5)=1.0 ---*/
+  solver_container[TURB_SOL]->node[iPoint]->SetSolution(0, 0);
   solver_container[TURB_SOL]->node[iPoint]->SetSolution(2, 4.0/3);
 
   /*--- Set alpha to be a realistic value ---*/
-  flow_avgs->SetKineticEnergyRatio(0.5);
+  flow_avgs->SetKineticEnergyRatio(pow(0.5, 1.0/1.7));
 
   /*--- Test --*/
 
@@ -323,7 +322,7 @@ BOOST_FIXTURE_TEST_CASE(SimpleRkTest, RkFixture) {
   const su2double r_k = flow_vars->GetResolutionAdequacy();
 
   const su2double tolerance = 10*std::numeric_limits<su2double>::epsilon();
-  BOOST_CHECK_CLOSE_FRACTION(r_k, su2double(1.0), tolerance);
+  BOOST_CHECK_CLOSE_FRACTION(r_k, su2double(0.75), tolerance);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -82,12 +82,16 @@ HYBRID_FORCING_PERIODIC_LENGTH= (-1, -1, -1)
 % The overall scaling for the hybrid forcing magnitude (8 by default)
 HYBRID_FORCING_STRENGTH= 8
 %
-% The number of turbulent lengthscales in a vortex period (4 by default)
-HYBRID_FORCING_VORTEX_LENGTH= 4
+% The number of turbulent lengthscales in a vortex period (8 by default)
+HYBRID_FORCING_VORTEX_LENGTH= 8
 %
 % The subgrid-energy transfer model used for model-split hybrid RANS/LES
 % (NONE, M43)
 SUBGRID_ENERGY_TRANSFER_MODEL= M43
+%
+% Increase SGS dissipation where locally over-resolved in model-split hybrid
+% (NO, YES, default: YES)
+USE_SGET_OVERRESOLUTION_FIX= YES
 %
 % Use the resolved turbulent stress for model-split hybrid RANS/LES (NO, YES)
 USE_RESOLVED_TURB_STRESS= YES


### PR DESCRIPTION
This distinguishes between alpha, the ratio of subfilter to total turbulent kinetic energy, and beta, the ratio of modeled to total turbulent kinetic energy.