### PR TITLE
Pecos cumulative averaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ branches:
     only:
         - pecos-dev
         - pecos-hybrid-fixes
+        - pecos-cumulative-averaging
 
 addons:
   apt:

--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -1115,10 +1115,11 @@ private:
   
 
   ofstream *ConvHistFile;       /*!< \brief Store the pointer to each history file */
-  unsigned short Kind_Averaging;  /*!< \brief Type of runtime-averaging to be performed. */
-  unsigned short Kind_Averaging_Period;  /*!< \brief Type of period over which runtime averages are to be computed. */
-  su2double nAveragingPeriods;  /*!< \brief Number of periods over which to average. */
-  su2double AveragingStartTime; /*!< \brief Amount of time to skip before averaging begins. */
+  unsigned short nKind_Runtime_Averaging; /*!< \brief The number of kinds of runtime-averaging to be performed. */
+  unsigned short* Kind_Runtime_Averaging;  /*!< \brief Type of runtime-averaging to be performed. */
+  unsigned short Kind_EWMA_Period;  /*!< \brief Type of period over which runtime averages are to be computed. */
+  su2double nEWMAPeriods;  /*!< \brief Number of periods over which to average. */
+  su2double CMAveragingStartTime; /*!< \brief Amount of time to skip before averaging begins. */
   bool Time_Domain;             /*!< \brief Determines if the multizone problem is solved in time-domain */
   unsigned long Outer_Iter,    /*!< \brief Determines the number of outer iterations in the multizone problem */
   Inner_Iter,                   /*!< \brief Determines the number of inner iterations in each multizone block */
@@ -9388,28 +9389,47 @@ public:
   void SetHistFile(ofstream *HistFile);
 
   /*!
+   * \brief Get the number of types of averaging to be performed.
+   * 
+   * For example, if EWMA and CMA are used, then this returns '2'.
+   * 
+   * \return The type of averaging to be performed
+   */
+  unsigned short GetnKind_Runtime_Averaging(void) const { return nKind_Runtime_Averaging; }
+
+  /*!
    * \brief Get the type of runtime averaging to be performed (or no averaging)
    * \return The type of averaging to be performed
    */
-  unsigned short GetKind_Averaging(void) const;
+  const unsigned short* GetKind_Runtime_Averaging(void) const { return Kind_Runtime_Averaging; };
+
+  /*!
+   * \brief Check if a specific type of averaging is enabled.
+   *
+   * \param[in] averaging_type - A averaging type matching the Averaging type enum.
+   * \return TRUE if the averaging type is enabled.
+   */
+  bool AveragingTypeIsEnabled(unsigned short averaging_type) const;
 
   /*!
    * \brief Get the type of time interval used as an averaging period.
    * \return The type of time interval to be performed.
    */
-  unsigned short GetKind_Averaging_Period(void) const;
+  unsigned short GetKind_EWMA_Period(void) const {
+    return Kind_EWMA_Period;
+  }
 
   /*!
    * \brief The number of time periods over which to average.
    * \return The number of time periods over which to average.
    */
-  su2double GetnAveragingPeriods(void) const;
+  su2double GetnEWMAPeriods(void) const { return nEWMAPeriods; }
 
   /*!
    * \brief Get The time at which to start runtime averaging.
    * \return The time at which to start runtime averaging.
    */
-  su2double GetAveragingStartTime(void) const;
+  su2double GetCMAveragingStartTime(void) const { return CMAveragingStartTime; }
 
   /*!
    * \brief Get the filenames of the individual config files

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -2113,14 +2113,6 @@ inline ofstream* CConfig::GetHistFile(void) { return ConvHistFile; }
 
 inline void CConfig::SetHistFile(ofstream *HistFile) { ConvHistFile = HistFile; }
 
-inline unsigned short CConfig::GetKind_Averaging(void) const { return Kind_Averaging; }
-
-inline unsigned short CConfig::GetKind_Averaging_Period(void) const { return Kind_Averaging_Period; }
-
-inline su2double CConfig::GetnAveragingPeriods(void) const { return nAveragingPeriods; }
-
-inline su2double CConfig::GetAveragingStartTime(void) const { return AveragingStartTime; }
-
 inline bool CConfig::GetTopology_Optimization(void) const { return topology_optimization; }
 
 inline string CConfig::GetTopology_Optim_FileName(void) const { return top_optim_output_file; }

--- a/Common/include/option_structure.hpp
+++ b/Common/include/option_structure.hpp
@@ -2045,14 +2045,16 @@ static const map<string, ENUM_INPUT_REF> Input_Ref_Map = CCreateMap<string, ENUM
 
 /*!
  * \brief Type of runtime averaging to be used.
+ *
+ * If no averaging is specified, averaging will not be performed
  */
 enum ENUM_RUNTIME_AVERAGING {
-  NO_AVERAGING,      /*!< \brief No averaging will be performed (default). */
-  POINTWISE_AVERAGE  /*!< \brief The average will be computed at each point. */
+  POINTWISE_EWMA, /*!< \brief The exponentially-weighted moving average will be computed at each point. */
+  POINTWISE_CMA  /*!< \brief The cumulative movign average will be computed at each point. */
 };
 static const map<string, ENUM_RUNTIME_AVERAGING> RuntimeAverage_Map = CCreateMap<string, ENUM_RUNTIME_AVERAGING>
-("NONE", NO_AVERAGING)
-("POINTWISE", POINTWISE_AVERAGE);
+("POINTWISE_EWMA", POINTWISE_EWMA)
+("POINTWISE_CMA", POINTWISE_CMA);
 
 /*!
  * \brief Time period over which to average.

--- a/Common/src/dual_grid_structure.cpp
+++ b/Common/src/dual_grid_structure.cpp
@@ -134,7 +134,8 @@ CPoint::CPoint(unsigned short val_nDim, unsigned long val_globalindex, CConfig *
 
   /*--- Initialize the grid resolution tensor ---*/
 
-  if (config->GetKind_HybridRANSLES() == MODEL_SPLIT) {
+  if (config->GetKind_HybridRANSLES() == MODEL_SPLIT ||
+      config->GetWrt_Resolution_Tensors()) {
     ResolutionTensor = new su2double*[nDim];
     ResolutionTensor43 = new su2double*[nDim];
     ResolutionValues = new su2double[nDim];
@@ -263,7 +264,8 @@ CPoint::CPoint(su2double val_coord_0, su2double val_coord_1, unsigned long val_g
 
   /*--- Initialize the grid resolution tensor ---*/
 
-  if (config->GetKind_HybridRANSLES() == MODEL_SPLIT) {
+  if (config->GetKind_HybridRANSLES() == MODEL_SPLIT ||
+      config->GetWrt_Resolution_Tensors()) {
     ResolutionTensor = new su2double*[nDim];
     ResolutionTensor43 = new su2double*[nDim];
     ResolutionValues = new su2double[nDim];
@@ -394,7 +396,8 @@ CPoint::CPoint(su2double val_coord_0, su2double val_coord_1, su2double val_coord
 
   /*--- Initialize the grid resolution tensor ---*/
 
-  if (config->GetKind_HybridRANSLES() == MODEL_SPLIT) {
+  if (config->GetKind_HybridRANSLES() == MODEL_SPLIT ||
+      config->GetWrt_Resolution_Tensors()) {
     ResolutionTensor = new su2double*[nDim];
     ResolutionTensor43 = new su2double*[nDim];
     ResolutionValues = new su2double[nDim];

--- a/Common/test/resolution_tensor_test.cpp
+++ b/Common/test/resolution_tensor_test.cpp
@@ -426,9 +426,7 @@ void WriteCfgFile(unsigned short nDim, const char* cfg_filename,
 
   cfg_file.open(cfg_filename, ios::out);
   cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
-  cfg_file << "HYBRID_RANSLES= MODEL_SPLIT" << std::endl;
-  cfg_file << "RUNTIME_AVERAGING= POINTWISE" << std::endl;
-  cfg_file << "UNSTEADY_SIMULATION= TIME_STEPPING" << std::endl;
+  cfg_file << "WRT_RESOLUTION_TENSORS= YES" << std::endl;
   if (nDim == 2)
     cfg_file << "MARKER_FAR= ( lower upper left right )"  << std::endl;
   else

--- a/SU2_CFD/include/output_structure.hpp
+++ b/SU2_CFD/include/output_structure.hpp
@@ -86,6 +86,7 @@ struct COutputVector {
   unsigned short Solver_Type;
   VectorAccessor Accessor;
   bool Average;
+  unsigned short size;
 };
 
 /*!
@@ -292,7 +293,7 @@ public:
 
   void RegisterVector(std::string name, std::string tecplot_name,
                       unsigned short solver_type, VectorAccessor accessor,
-                      unsigned short val_zone, bool average = false);
+                      unsigned short val_zone, bool average = false, unsigned short size=3);
 
   /*!
    * \brief Add a tensor to the list of extra variables to be used in output

--- a/SU2_CFD/include/solver_structure.hpp
+++ b/SU2_CFD/include/solver_structure.hpp
@@ -8741,6 +8741,8 @@ private:
 
   CAbstract_Hybrid_Mediator *HybridMediator; /*!< \brief A mediator object for a hybrid RANS/LES model. */
 
+  unsigned long CMA_count; /*!< \brief Number of CMA iterations taken so far. */
+
 public:
   
   /*!
@@ -9224,6 +9226,13 @@ public:
    * \param[in] hybrid_mediator - The mediator object
    */
   void AddHybridMediator(CAbstract_Hybrid_Mediator *hybrid_mediator);
+
+  /*!
+   * \brief Update the cumulative moving average in a non-steady problem.
+   *
+   * This function should only be called once per (outermost) iteration.
+   */
+  void UpdateCMAverage();
 };
 
 /*!

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -2605,6 +2605,9 @@ public:
 
   virtual su2double GetSolution_Old_Accel(unsigned short iVar);
 
+  virtual const su2double* GetCMA_variables() const {return NULL;};
+
+  virtual void AddCMA_variables(const su2double* values) { };
 };
 
 /*!
@@ -4054,6 +4057,11 @@ private:
   su2double ResolvedKineticEnergy; /*!< \brief The resolved portion of the turbulent kinetic energy. */
   su2double TurbProduction; /*!< \brief The total production of turbulent kinetic energy. */
   su2double SGSProduction; /*!< \brief The subgrid portion of the production of TKE */
+
+
+  /*--- Cumulative average variables ---*/
+
+  su2double* CMA_variables; /*!< \brief Array of average variables */
   
 public:
   
@@ -4378,6 +4386,19 @@ public:
    */
   void SetRoe_Dissipation(su2double val_dissipation);
   
+  const su2double* GetCMA_variables() const override { return CMA_variables; }
+
+  void AddCMA_variables(const su2double* values) override {
+    assert(CMA_variables);
+    assert(CMA_variables != NULL);
+    for (unsigned short iVar = 0; iVar < nCMA_variables; iVar++) {
+      CMA_variables[iVar] += values[iVar];
+    }
+  }
+
+  /*--- 5 convservative variables, 6 velocity variances,
+    5 other primitive variable covariances ---*/
+  static constexpr unsigned short nCMA_variables = 5+6+5; /*!< \brief Number of CMA variables being used */
 };
 
 /*!

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -4789,6 +4789,14 @@ public:
    * \param[in] val_turb_L - Large eddy lengthscale of the turbulence
    */
   void SetTurbScales(su2double val_turb_T, su2double val_turb_L);
+
+  su2double GetTypicalTimescale() const override {
+     return T;
+  };
+
+  su2double GetTypicalLengthscale() const override {
+    return L;
+  }
 };
 
 /*!

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -1477,7 +1477,7 @@ void CDriver::Solver_Preprocessing(CSolver ****solver_container, CGeometry ***ge
   /*--- Initialize the averages ---*/
 
   if (!config->GetRestart() && !config->GetRestart_Flow() &&
-      config->GetKind_Averaging() != NO_AVERAGING) {
+      config->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
     for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
       solver_container[val_iInst][iMGlevel][FLOW_SOL]->InitAverages();
       if (turbulent) {

--- a/SU2_CFD/src/hybrid_RANS_LES_model.cpp
+++ b/SU2_CFD/src/hybrid_RANS_LES_model.cpp
@@ -283,7 +283,7 @@ void CHybrid_Mediator::SetupResolvedFlowNumerics(const CGeometry* geometry,
    * dimensional ---*/
   const su2double time = config->GetCurrent_UnstTime();
 
-  if (time > config->GetAveragingStartTime()) {
+  if (time > config->GetCMAveragingStartTime()) {
     su2double* primvar_i =
         solver_container[FLOW_SOL]->average_node[iPoint]->GetPrimitive();
     su2double* primvar_j =

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -736,6 +736,10 @@ void CFluidIteration::Update(COutput *output,
   }
 
   /*--- Update averages ---*/
+  if (true) {
+    CNSSolver* fluid_solver = dynamic_cast<CNSSolver*>(solver_container[val_iZone][val_iInst][MESH_0][FLOW_SOL]);
+    fluid_solver->UpdateCMAverage();
+  }
   if (config_container[val_iZone]->GetKind_Averaging() != NO_AVERAGING) {
     /*--- We check this when setting up, so this assert should never be false ---*/
     assert(config_container[val_iZone]->GetUnsteady_Simulation() != STEADY);

--- a/SU2_CFD/src/iteration_structure.cpp
+++ b/SU2_CFD/src/iteration_structure.cpp
@@ -736,11 +736,14 @@ void CFluidIteration::Update(COutput *output,
   }
 
   /*--- Update averages ---*/
-  if (true) {
-    CNSSolver* fluid_solver = dynamic_cast<CNSSolver*>(solver_container[val_iZone][val_iInst][MESH_0][FLOW_SOL]);
-    fluid_solver->UpdateCMAverage();
+  if (config_container[val_iZone]->AveragingTypeIsEnabled(POINTWISE_CMA)) {
+    const su2double time = config_container[val_iZone]->GetCurrent_UnstTimeND();
+    if (time > config_container[val_iZone]->GetCMAveragingStartTime()) {
+      CNSSolver* fluid_solver = dynamic_cast<CNSSolver*>(solver_container[val_iZone][val_iInst][MESH_0][FLOW_SOL]);
+      fluid_solver->UpdateCMAverage();
+    }
   }
-  if (config_container[val_iZone]->GetKind_Averaging() != NO_AVERAGING) {
+  if (config_container[val_iZone]->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
     /*--- We check this when setting up, so this assert should never be false ---*/
     assert(config_container[val_iZone]->GetUnsteady_Simulation() != STEADY);
     for (iMesh = 0; iMesh <= config_container[val_iZone]->GetnMGLevels(); iMesh++) {

--- a/SU2_CFD/src/numerics_direct_mean_hybrid.cpp
+++ b/SU2_CFD/src/numerics_direct_mean_hybrid.cpp
@@ -201,7 +201,7 @@ void CAvgGrad_Hybrid::ComputeResidual(su2double *val_residual, su2double **val_J
 #ifndef NDEBUG
   // Check that fluctuations are zero if averaging is not to be performed
   const su2double time = config->GetCurrent_UnstTime();
-  if (time < config->GetAveragingStartTime()) {
+  if (time < config->GetCMAveragingStartTime()) {
     for (iVar = 0; iVar < nDim+1; iVar++) {
       for (iDim = 0; iDim < nDim; iDim++) {
         assert(abs(Mean_GradPrimVar_Fluct[iVar][iDim]) < EPS);

--- a/SU2_CFD/src/output_cgns.cpp
+++ b/SU2_CFD/src/output_cgns.cpp
@@ -434,7 +434,7 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
   }
   
   /*--- Write averages to CGNS file ---*/
-  if (config->GetKind_Averaging() != NO_AVERAGING) {
+  if (config->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
     for (jVar = 0; jVar < nVar_Consv; jVar++) {
       name.str(string()); name << "Average " << jVar+1;
       cgns_err = cg_field_write(cgns_file, cgns_base, cgns_zone, cgns_flow, RealDouble,(char *)name.str().c_str(), Data[iVar], &cgns_field); iVar++;

--- a/SU2_CFD/src/output_fieldview.cpp
+++ b/SU2_CFD/src/output_fieldview.cpp
@@ -196,7 +196,7 @@ void COutput::SetFieldViewASCII(CConfig *config, CGeometry *geometry, unsigned s
     
     /*--- Add names for any extra variables (this will need to be adjusted). ---*/
 
-    if (config->GetKind_Averaging()) {
+    if (config->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
         FieldView_File << "Average_" << iVar+1 << endl;
       }

--- a/SU2_CFD/src/output_paraview.cpp
+++ b/SU2_CFD/src/output_paraview.cpp
@@ -593,8 +593,8 @@ void COutput::SetParaview_ASCII(CConfig *config, CGeometry *geometry, unsigned s
       }
       VarCounter++;
     }
-    
-    if (config->GetKind_Averaging() != NO_AVERAGING) {
+
+    if (config->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
 
         Paraview_File << "\nSCALARS Average_" << iVar+1 << " float 1\n";
@@ -1608,7 +1608,7 @@ void COutput::SetParaview_MeshASCII(CConfig *config, CGeometry *geometry, unsign
       VarCounter++;
     }
 
-    if (config->GetKind_Averaging() != NO_AVERAGING) {
+    if (config->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
 
         Paraview_File << "\nSCALARS Average_" << iVar+1 << " float 1\n";
@@ -1628,7 +1628,7 @@ void COutput::SetParaview_MeshASCII(CConfig *config, CGeometry *geometry, unsign
         VarCounter++;
       }
     }
-    
+
     if (config->GetWrt_Limiters()) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
         

--- a/SU2_CFD/src/output_tecplot.cpp
+++ b/SU2_CFD/src/output_tecplot.cpp
@@ -187,7 +187,7 @@ void COutput::SetTecplotASCII(CConfig *config, CGeometry *geometry, CSolver **so
       
       for (std::vector<COutputVector>::iterator it = output_vectors[val_iZone].begin();
            it != output_vectors[val_iZone].end(); ++it) {
-        for (iDim = 1; iDim < nDim+1; iDim++) {
+        for (iDim = 1; iDim < (it->size + 1); iDim++) {
           Tecplot_File << ", \"" << it->Tecplot_Name;
           Tecplot_File << "<sub>" << iDim << "</sub>\"";
         }
@@ -3550,7 +3550,7 @@ string COutput::AssembleVariableNames(CGeometry *geometry, CConfig *config, unsi
     
     for (std::vector<COutputVector>::iterator it = output_vectors[val_iZone].begin();
          it != output_vectors[val_iZone].end(); ++it) {
-      for (unsigned short iDim = 1; iDim < nDim+1; iDim++) {
+      for (unsigned short iDim = 1; iDim < (it->size + 1); iDim++) {
           variables << it->Name << "_" << iDim << " ";
           *NVar += 1;
       }

--- a/SU2_CFD/src/output_tecplot.cpp
+++ b/SU2_CFD/src/output_tecplot.cpp
@@ -138,8 +138,8 @@ void COutput::SetTecplotASCII(CConfig *config, CGeometry *geometry, CSolver **so
     for (iVar = 0; iVar < nVar_Consv; iVar++) {
       Tecplot_File << ",\"Conservative_" << iVar+1 << "\"";
     }
-    
-    if (config->GetKind_Averaging() != NO_AVERAGING) {
+
+    if (config->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
         Tecplot_File << ",\"Average_" << iVar+1 << "\"";
       }
@@ -3496,7 +3496,8 @@ string COutput::AssembleVariableNames(CGeometry *geometry, CConfig *config, unsi
     for (iVar = 0; iVar < nVar_Consv; iVar++) {
       variables << "Conservative_" << iVar+1<<" "; *NVar += 1;
     }
-    if (config->GetKind_Averaging()) {
+
+    if (config->AveragingTypeIsEnabled(POINTWISE_EWMA)) {
       for (iVar = 0; iVar < nVar_Consv; iVar++) {
         variables << "Average_" << iVar+1<<" "; *NVar += 1;
       }

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -1403,7 +1403,7 @@ void CTurbSolver::LoadRestart(CGeometry **geometry, CSolver ***solver, CConfig *
   ifstream restart_file;
   string restart_filename = config->GetSolution_FlowFileName();
 
-  const bool runtime_averaging = (config->GetKind_Averaging() != NO_AVERAGING);
+  const bool runtime_averaging = config->AveragingTypeIsEnabled(POINTWISE_EWMA);
 
   /*--- Modify file name for multizone problems ---*/
   if (nZone >1)
@@ -1554,7 +1554,7 @@ CTurbSASolver::CTurbSASolver(CGeometry *geometry, CConfig *config, unsigned shor
   unsigned short iVar, iDim, nLineLets;
   unsigned long iPoint;
   su2double Density_Inf, Viscosity_Inf, Factor_nu_Inf, Factor_nu_Engine, Factor_nu_ActDisk;
-  const bool runtime_averaging = (config->GetKind_Averaging() != NO_AVERAGING);
+  const bool runtime_averaging = config->AveragingTypeIsEnabled(POINTWISE_EWMA);
 
   bool multizone = config->GetMultizone_Problem();
 
@@ -3918,7 +3918,7 @@ CTurbSSTSolver::CTurbSSTSolver(CGeometry *geometry, CConfig *config, unsigned sh
   string text_line;
   bool multizone = config->GetMultizone_Problem();
 
-  const bool runtime_averaging = (config->GetKind_Averaging() != NO_AVERAGING);
+  const bool runtime_averaging = config->AveragingTypeIsEnabled(POINTWISE_EWMA);
 
   
   /*--- Array initialization ---*/

--- a/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
@@ -57,7 +57,7 @@ CTurbKESolver::CTurbKESolver(CGeometry *geometry, CConfig *config,
   unsigned long iPoint;
   ifstream restart_file;
   string text_line;
-  const bool runtime_averaging = (config->GetKind_Averaging() != NO_AVERAGING);
+  const bool runtime_averaging = config->AveragingTypeIsEnabled(POINTWISE_EWMA);
 
   int rank = MASTER_NODE;
 #ifdef HAVE_MPI

--- a/SU2_CFD/src/variable_direct_mean.cpp
+++ b/SU2_CFD/src/variable_direct_mean.cpp
@@ -579,6 +579,10 @@ CNSVariable::CNSVariable(void) : CEulerVariable() {
   for (unsigned short iDim = 0; iDim < nDim; iDim++) {
     ForcingVector[iDim] = 0;
   }
+  CMA_variables = new su2double[nCMA_variables];
+  for (unsigned short iVar=0; iVar < nCMA_variables; iVar++) {
+      CMA_variables[iVar] = 0.0;
+  }
 }
 
 CNSVariable::CNSVariable(su2double val_density, su2double *val_velocity, su2double val_energy,
@@ -618,6 +622,10 @@ CNSVariable::CNSVariable(su2double val_density, su2double *val_velocity, su2doub
     for (unsigned short iDim = 0; iDim < nDim; iDim++) {
       ForcingVector[iDim] = 0;
     }
+    CMA_variables = new su2double[nCMA_variables];
+    for (unsigned short iVar=0; iVar < nCMA_variables; iVar++) {
+        CMA_variables[iVar] = 0.0;
+    }
 
 }
 
@@ -656,8 +664,10 @@ CNSVariable::CNSVariable(su2double *val_solution, unsigned short val_nDim,
     for (unsigned short iDim = 0; iDim < nDim; iDim++) {
       ForcingVector[iDim] = 0;
     }
-    
-
+    CMA_variables = new su2double[nCMA_variables];
+    for (unsigned short iVar = 0; iVar < nCMA_variables; iVar++) {
+      CMA_variables[iVar] = 0.0;
+    }
 }
 
 CNSVariable::~CNSVariable(void) {
@@ -675,6 +685,9 @@ CNSVariable::~CNSVariable(void) {
   }
   if (ForcingVector != NULL) {
     delete [] ForcingVector;
+  }
+  if (CMA_variables != NULL) {
+    delete [] CMA_variables;
   }
 }
 

--- a/SU2_CFD/test/averaging_timescale_test.cpp
+++ b/SU2_CFD/test/averaging_timescale_test.cpp
@@ -61,8 +61,8 @@ static void WriteCfgFile(const char* filename, const string& period) {
   cfg_file.open(filename, ios::out);
   cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
   cfg_file << "TIME_DISCRE_FLOW= EULER_IMPLICIT" << std::endl;
-  cfg_file << "NUM_AVERAGING_PERIODS= 4.0" << std::endl;
-  cfg_file << "AVERAGING_PERIOD= " << period << std::endl;
+  cfg_file << "EWMA_NUM_AVERAGING_PERIODS= 4.0" << std::endl;
+  cfg_file << "EWMA_AVERAGING_PERIOD= " << period << std::endl;
 
   cfg_file.close();
 

--- a/SU2_CFD/test/cumulative_average_test.cpp
+++ b/SU2_CFD/test/cumulative_average_test.cpp
@@ -1,0 +1,219 @@
+/*!
+ * \file cumulative_average_test.cpp
+ * \brief Tests the cumulative moving average
+ * \author C. Pederson
+ * \version 6.1.0 "Falcon"
+ *
+ * The current SU2 release has been coordinated by the
+ * SU2 International Developers Society <www.su2devsociety.org>
+ * with selected contributions from the open-source community.
+ *
+ * The main research teams contributing to the current release are:
+ *  - Prof. Juan J. Alonso's group at Stanford University.
+ *  - Prof. Piero Colonna's group at Delft University of Technology.
+ *  - Prof. Nicolas R. Gauger's group at Kaiserslautern University of Technology.
+ *  - Prof. Alberto Guardone's group at Polytechnic University of Milan.
+ *  - Prof. Rafael Palacios' group at Imperial College London.
+ *  - Prof. Vincent Terrapon's group at the University of Liege.
+ *  - Prof. Edwin van der Weide's group at the University of Twente.
+ *  - Lab. of New Concepts in Aeronautics at Tech. Institute of Aeronautics.
+ *
+ * Copyright 2012-2018, Francisco D. Palacios, Thomas D. Economon,
+ *                      Tim Albring, and the SU2 contributors.
+ *
+ * SU2 is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * SU2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with SU2. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+#include <limits> // used to find machine epsilon
+
+#include "../include/solver_structure.hpp"
+#include "../include/solver_structure_v2f.hpp"
+#include "../include/variable_structure_v2f.hpp"
+
+namespace cumulative_average_test {
+
+const unsigned short nDim = 3;
+const unsigned short nVar = nDim+2;
+const unsigned short nPrimVar = nDim+9;
+const unsigned short nSecVar = 4;
+
+/**
+ * Write a cfg file to be used in initializing the CConfig object.
+ */
+static void WriteCfgFile(const char* filename, const string& period) {
+
+  std::ofstream cfg_file;
+
+  cfg_file.open(filename, ios::out);
+  cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
+  cfg_file << "TIME_DISCRE_FLOW= EULER_IMPLICIT" << std::endl;
+
+  cfg_file.close();
+
+}
+
+class CTestGeometry : public CGeometry {
+ public:
+  CTestGeometry(CConfig* config) : CGeometry() {
+    nPoint = 1;
+    node = new CPoint*[nPoint];
+    for (unsigned short iPoint = 0; iPoint < nPoint; iPoint++) {
+      node[iPoint] = new CPoint(0, 0, 0, iPoint, config);
+      node[iPoint]->SetVolume(1);
+    }
+  };
+};
+
+class CTestSolver : public CNSSolver {
+ public:
+  CTestSolver(su2double* initial_solution,
+              unsigned short val_nDim, unsigned short val_nVar,
+              CConfig* config)
+       : CNSSolver() {
+
+    nDim = val_nDim;
+    nVar = val_nVar;
+    nPoint = 1;
+    nPointDomain = 1;
+
+    Solution = new su2double[val_nVar];
+
+    node = new CVariable*[nPoint];
+    average_node = NULL;
+
+    su2double* velocity = new su2double[nDim];
+    for (unsigned short iDim = 0; iDim < nDim; iDim++) {
+      velocity[iDim] = initial_solution[iDim+1]/initial_solution[0];
+    }
+
+    const su2double density = initial_solution[0];
+    const su2double energy = initial_solution[nDim+1];
+
+    for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
+      node[iPoint] = new CNSVariable(density, velocity, energy, nDim, nVar, config);
+    }
+
+    delete [] velocity;
+  };
+
+  ~CTestSolver() {
+  }
+
+};
+
+
+struct CMA_Fixture {
+  CMA_Fixture() {
+
+    char cfg_filename[100] = "averaging_timescale_test.cfg";
+    WriteCfgFile(cfg_filename, "FLOW_TIMESCALE");
+    const unsigned short iZone = 0;
+    const unsigned short nZone = 1;
+    config = new CConfig(cfg_filename, SU2_CFD, iZone, nZone, 2, VERB_NONE);
+    std::remove(cfg_filename);
+
+    su2double solution[5] = {1.0, 0.0, 0.0, 0.0, 0.0};
+    solver = new CTestSolver(solution, nDim, nVar, config);
+    solver->UpdateCMAverage();
+
+  }
+  ~CMA_Fixture() {
+    delete config;
+    delete solver;
+  }
+
+  CConfig* config;
+  CTestSolver* solver;
+};
+
+
+BOOST_AUTO_TEST_SUITE(CumulativeMovingAverage);
+
+BOOST_FIXTURE_TEST_CASE(CumulativeAverageOfDensity, CMA_Fixture) {
+
+  /*--- Act ---*/
+
+  su2double solution[5] = {1.0, 0.0, 0.0, 0.0, 0.0};
+  solution[0] = 3.0;
+  solver->node[0]->SetSolution(solution);
+  solver->UpdateCMAverage();
+  const su2double density_1 = solver->node[0]->GetCMA_variables()[0];
+
+  solution[0] = 5.0;
+  solver->node[0]->SetSolution(solution);
+  solver->UpdateCMAverage();
+  const su2double density_2 = solver->node[0]->GetCMA_variables()[0];
+
+  /*--- Assert ---*/
+
+  const su2double tolerance = 10*std::numeric_limits<su2double>::epsilon();
+  BOOST_CHECK_CLOSE_FRACTION(density_1, 2.0, tolerance);
+  BOOST_CHECK_CLOSE_FRACTION(density_2, 3.0, tolerance);
+
+}
+
+BOOST_FIXTURE_TEST_CASE(CumulativeAverageOfMomentum, CMA_Fixture) {
+
+  /*--- Act ---*/
+
+  su2double solution[5] = {1.0, 0.0, 0.0, 0.0, 0.0};
+  solution[1] = 2.0;
+  solver->node[0]->SetSolution(solution);
+  solver->UpdateCMAverage();
+  const su2double momentum_1 = solver->node[0]->GetCMA_variables()[1];
+
+  solution[1] = 4.0;
+  solver->node[0]->SetSolution(solution);
+  solver->UpdateCMAverage();
+  const su2double momentum_2 = solver->node[0]->GetCMA_variables()[1];
+
+  /*--- Assert ---*/
+  const su2double tolerance = 10*std::numeric_limits<su2double>::epsilon();
+  BOOST_CHECK_CLOSE_FRACTION(momentum_1, 1.0, tolerance);
+  BOOST_CHECK_CLOSE_FRACTION(momentum_2, 2.0, tolerance);
+
+}
+
+BOOST_FIXTURE_TEST_CASE(CumulativeAverageOfUU, CMA_Fixture) {
+
+  /*--- Act ---*/
+
+  su2double solution[5] = {1.0, 0.0, 0.0, 0.0, 0.0};
+  solution[1] = 3.0;
+  solver->node[0]->SetSolution(solution);
+  solver->node[0]->SetVelocity();
+  solver->UpdateCMAverage();
+  const su2double uu_1 = solver->node[0]->GetCMA_variables()[5];
+
+  solution[1] = 3.0;
+  solver->node[0]->SetSolution(solution);
+  solver->node[0]->SetVelocity();
+  solver->UpdateCMAverage();
+  const su2double uu_2 = solver->node[0]->GetCMA_variables()[5];
+
+  /*--- Assert ---*/
+
+  const su2double tolerance = 10*std::numeric_limits<su2double>::epsilon();
+  BOOST_CHECK_CLOSE_FRACTION(uu_1, 4.5, tolerance);
+  BOOST_CHECK_CLOSE_FRACTION(uu_2, 6.0, tolerance);
+
+}
+
+
+BOOST_AUTO_TEST_SUITE_END();
+
+} // end namespace

--- a/SU2_CFD/test/fluctuating_stress_test.cpp
+++ b/SU2_CFD/test/fluctuating_stress_test.cpp
@@ -225,7 +225,7 @@ struct FluctuatingStressFixture {
     cfg_file.open(filename, ios::out);
     cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
     cfg_file << "HYBRID_RANSLES= MODEL_SPLIT" << std::endl;
-    cfg_file << "RUNTIME_AVERAGING= POINTWISE" << std::endl;
+    cfg_file << "RUNTIME_AVERAGING= POINTWISE_EWMA" << std::endl;
     cfg_file << "UNSTEADY_SIMULATION= TIME_STEPPING" << std::endl;
     cfg_file << "KIND_TURB_MODEL= KE" << std::endl;
     if (nDim == 2)

--- a/SU2_CFD/test/forcing_test.cpp
+++ b/SU2_CFD/test/forcing_test.cpp
@@ -49,7 +49,7 @@ static void WriteCfgFile(const char* filename) {
   cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
   cfg_file << "KIND_TURB_MODEL= KE" << std::endl;
   cfg_file << "HYBRID_RANSLES= MODEL_SPLIT" << std::endl;
-  cfg_file << "RUNTIME_AVERAGING= POINTWISE" << std::endl;
+  cfg_file << "RUNTIME_AVERAGING= POINTWISE_EWMA" << std::endl;
   cfg_file << "UNSTEADY_SIMULATION= TIME_STEPPING" << std::endl;
   cfg_file << "HYBRID_FORCING_PERIODIC_LENGTH= (";
   cfg_file << std::setprecision(std::numeric_limits<su2double>::digits10 + 1);

--- a/SU2_CFD/test/hybrid_rdelta_test.cpp
+++ b/SU2_CFD/test/hybrid_rdelta_test.cpp
@@ -56,7 +56,7 @@ static void WriteCfgFile(unsigned short nDim, const char* filename) {
   cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
   cfg_file << "KIND_TURB_MODEL= KE" << std::endl;
   cfg_file << "HYBRID_RANSLES= MODEL_SPLIT" << std::endl;
-  cfg_file << "RUNTIME_AVERAGING= POINTWISE" << std::endl;
+  cfg_file << "RUNTIME_AVERAGING= POINTWISE_EWMA" << std::endl;
   cfg_file << "UNSTEADY_SIMULATION= TIME_STEPPING" << std::endl;
   cfg_file.close();
 

--- a/SU2_CFD/test/load_heterogeneous_restart.cpp
+++ b/SU2_CFD/test/load_heterogeneous_restart.cpp
@@ -116,7 +116,7 @@ struct HetergeneousRestartFixture {
     cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
     cfg_file << "KIND_TURB_MODEL= KE" << std::endl;
     cfg_file << "HYBRID_RANSLES= MODEL_SPLIT" << std::endl;
-    cfg_file << "RUNTIME_AVERAGING= POINTWISE" << std::endl;
+    cfg_file << "RUNTIME_AVERAGING= POINTWISE_EWMA" << std::endl;
     cfg_file << "UNSTEADY_SIMULATION= TIME_STEPPING" << std::endl;
     cfg_file.close();
   }

--- a/SU2_CFD/test/meson.build
+++ b/SU2_CFD/test/meson.build
@@ -26,6 +26,7 @@ SU2_CFD_boost_tests = files(['convective_blending_test.cpp',
                              'viscous_residual_2d_test.cpp',
                              'viscous_model_split.cpp',
                              'averaging_timescale_test.cpp',
+                             'cumulative_average_test.cpp',
                              'main.cpp'])
 
 if mkl_dep.found()

--- a/SU2_CFD/test/resolution_adequacy.cpp
+++ b/SU2_CFD/test/resolution_adequacy.cpp
@@ -63,7 +63,7 @@ static void WriteCfgFile(const char* filename) {
   cfg_file.open(filename, ios::out);
   cfg_file << "PHYSICAL_PROBLEM= NAVIER_STOKES" << std::endl;
   cfg_file << "HYBRID_RANSLES= MODEL_SPLIT" << std::endl;
-  cfg_file << "RUNTIME_AVERAGING= POINTWISE" << std::endl;
+  cfg_file << "RUNTIME_AVERAGING= POINTWISE_EWMA" << std::endl;
   cfg_file << "UNSTEADY_SIMULATION= TIME_STEPPING" << std::endl;
   cfg_file << "KIND_TURB_MODEL= KE" << std::endl;
   cfg_file.close();

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1003,7 +1003,7 @@ ROE_LOW_DISSIPATION= FD
 % blending. Values below 0.005 are unstable for some simulations.
 %   0.01 was used for low-Mach channel
 %   0.04 was used for axisymmetric bump results in report (0.01 default)
-ROW_LOW_DISSIPATION_MIN= 0.01
+ROE_LOW_DISSIPATION_MIN= 0.01
 %
 % Post-reconstruction correction for low Mach number flows (NO, YES)
 LOW_MACH_CORR= NO
@@ -1567,18 +1567,19 @@ OPT_COMBINE_OBJECTIVE = NO
 
 % -------------------- RUNTIME AVERAGING OPTIONS ---------------------------- %
 %
-% Type of averaging to be performed. (NONE, POINTWISE)
-RUNTIME_AVERAGING= NONE
+% Type(s) of averaging to be performed. (NONE, POINTWISE_EWMA, POINTWISE_CMA)
+% Only POINTWISE_EWMA can be used for hybrid RANS/LES
+RUNTIME_AVERAGING= ( NONE )
 %
 % Type of time period over which the averaging will be applied.
 % (FLOW_TIMESCALE, TURB_TIMESCALE, MAX_TURB_TIMESCALE)
-AVERAGING_PERIOD= FLOW_TIMESCALE
+EWMA_AVERAGING_PERIOD= FLOW_TIMESCALE
 %
 % Number of time periods over which to average (can be a non-integer)
-NUM_AVERAGING_PERIODS= 4.0
+EWMA_NUM_AVERAGING_PERIODS= 4.0
 %
-% Time at which to begin runtime averaging
-AVERAGING_START_TIME= 0.0
+% Time at which to begin runtime averaging for the cumulative moving average
+CMA_AVERAGING_START_TIME= 0.0
 %
 % Relaxation factor applied to updates of "average" production
 PRODUCTION_RELAXATION= 0.5


### PR DESCRIPTION
This add a cumulative average to the runtime averaging in SU2.  This allows statistics such as the mean flow and velocity variances to be calculated at runtime.

This differs from the exponentially-weighted moving average (EWMA) in that the EWMA always gives recent points a higher weight than past points.  For oscillatory problems, that means it will always "follow" the oscillations.  

A cumulative average will average out the oscillations, if given enough integration time.