### PR TITLE
Small changes in the v2-f model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ sudo: required
 # Language = c or c++ is necessary for easy use of ccache and Travis caching
 language: c++
 
+# Pip caching is not necessary.  It only saves a few seconds total.
+cache:
+    - ccache
+
 compiler:
     - gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ sudo: required
 # Language = c or c++ is necessary for easy use of ccache and Travis caching
 language: c++
 
-# Pip caching is not necessary.  It only saves a few seconds total.
-cache:
-    - ccache
-
 compiler:
     - gcc
 

--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -1156,6 +1156,7 @@ private:
   unsigned short Kind_v2f_Limit; /*!< \brief Type of realizability limit imposed on the v2-f RANS model. */
   su2double v2f_Realizability_Constant; /*!< \brief The model constant used in the realizability limit. This is `C_lim` from Sveningsson and Davidson. */
   su2double v2f_Ce1_Constant;
+  su2double v2f_Rf_Constant;
   bool Use_TKE_Diffusion; /*!< \brief Add TKE diffusion model for the molecular and turbulent transport of total energy. */
 
   /*--- all_options is a map containing all of the options. This is used during config file parsing
@@ -5191,6 +5192,8 @@ public:
   su2double Getv2f_Realizability_Constant(void) const;
 
   su2double Getv2f_Ce1_Constant(void) const { return v2f_Ce1_Constant; }
+
+  su2double Getv2f_Rf_Constant(void) const { return v2f_Rf_Constant; }
 
   /*!
    * \brief  Add TKE diffusion model for the molecular and turbulent

--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -4425,13 +4425,6 @@ public:
   void SetUse_Resolved_Turb_Stress(bool use_stress);
 
   /*!
-   * \brief Check if the timescale limit should be used in the v2-f
-   *        RANS model.
-   * \return True if the timescale limit should be used.
-   */
-  bool GetUse_v2f_Timescale_Limit(void) const;
-
-  /*!
    * \brief Get the kind of the turbulence model.
    * \return Kind of the turbulence model.
    */

--- a/Common/include/config_structure.inl
+++ b/Common/include/config_structure.inl
@@ -1299,8 +1299,6 @@ inline bool CConfig::GetBoolUse_v2f_Rf_mod(void) { return Use_v2f_Rf_mod; }
 
 inline bool CConfig::GetBoolUse_v2f_Explicit_WallBC(void) { return Use_v2f_Explicit_WallBC; }
 
-inline bool CConfig::GetUse_v2f_Timescale_Limit(void) const { return Use_v2f_Timescale_Limit; }
-
 inline unsigned short CConfig::GetKind_v2f_Limit(void) const { return Kind_v2f_Limit; }
 
 inline su2double CConfig::Getv2f_Realizability_Constant(void) const { return v2f_Realizability_Constant; }

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1183,10 +1183,10 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   /*!\brief V2F_REALIZABILITY_CONSTANT \n DESCRIPTION: The model constant used in the realizability limit. This is `C_lim` from Sveningsson and Davidson. \n DEFAULT: 0.6 \ingroup Config */
   addDoubleOption("V2F_REALIZABILITY_CONSTANT", v2f_Realizability_Constant, 0.6);
 
-  addDoubleOption("V2F_CE1_CONSTANT", v2f_Ce1_Constant, 0.045);
+  addDoubleOption("V2F_CE1_CONSTANT", v2f_Ce1_Constant, 0.05);
 
   /*!\brief V2F_RF_CONSTANT \n DESCRIPTION: If the Rf mod is used, then this is the constant in the numerator of Rf. \n DEFAULT: 3.0 \ingroup Config */
-  addDoubleOption("V2F_RF_CONSTANT", v2f_Rf_Constant, 3.0);
+  addDoubleOption("V2F_RF_CONSTANT", v2f_Rf_Constant, 1.5);
 
   /*!\brief KEEP_PV2_NONNEGATIVE  \n DESCRIPTION: Limit the production of v2 to non-negative values in the v2-f RANS model. \n DEFAULT: True \ingroup Config*/
   addBoolOption("KEEP_PV2_NONNEGATIVE", Pv2_nonnegative, true);

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1185,6 +1185,9 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
 
   addDoubleOption("V2F_CE1_CONSTANT", v2f_Ce1_Constant, 0.045);
 
+  /*!\brief V2F_RF_CONSTANT \n DESCRIPTION: If the Rf mod is used, then this is the constant in the numerator of Rf. \n DEFAULT: 3.0 \ingroup Config */
+  addDoubleOption("V2F_RF_CONSTANT", v2f_Rf_Constant, 3.0);
+
   /*!\brief KEEP_PV2_NONNEGATIVE  \n DESCRIPTION: Limit the production of v2 to non-negative values in the v2-f RANS model. \n DEFAULT: True \ingroup Config*/
   addBoolOption("KEEP_PV2_NONNEGATIVE", Pv2_nonnegative, true);
 

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -816,9 +816,6 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   /*!\brief USE_RESOLVED_TURB_STRESS \n DESCRIPTION: Use the resolved turbulent stress in stead of improved production for hybrid RANS/LES calculations. \ingroup Config*/
   addBoolOption("USE_RESOLVED_TURB_STRESS", Use_Resolved_Turb_Stress, YES);
 
-  /*!\brief V2F_TIMESCALE_LIMIT \n DESCRITPTION: For the v2-f RANS model, limit the timescale in the f-equation to 3/S, where S is the Frobenius norm of the mean rate-of-strain tensor. \ingroup Config */
-  addBoolOption("V2F_TIMESCALE_LIMIT", Use_v2f_Timescale_Limit, NO);
-
   /*!\brief KIND_V2F_LIMIT \n DESCRITPTION: Specify the type of realizability limit to be used for the v2-f RANS model. \n Options: see \link v2f_Limit_Map \endlink \n DEFAULT: EDDY_VISC_LIMIT \ingroup Config */
   addEnumOption("KIND_V2F_LIMIT", Kind_v2f_Limit, v2f_Limit_Map, EDDY_VISC_LIMIT);
 

--- a/SU2_CFD/include/numerics_structure_v2f.hpp
+++ b/SU2_CFD/include/numerics_structure_v2f.hpp
@@ -164,6 +164,8 @@ private:
   C_e2;
   /*--- Coefficient used in the C_e1 equation (usually 0.045 or 0.05) ---*/
   su2double C_e1_factor;
+  /*--- Constant in the numerator of the Rf modification in the f-eqn ---*/
+  su2double Rf_constant;
 
   su2double** ResolvedTurbStress; /*!< \brief Resolved portion of the Reynolds stress */
   su2double SGSProduction; /*!< \brief Production due to the mean turbulent stress, below the filter scale. */

--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -1253,12 +1253,14 @@ public:
    * \param[in] L_inf - The freestream (or problem) lengthscale
    * \param[in] use_realizability - Limit the time and lengthscales based
    *     on realizability limits on the Reynolds stress tensor.
+   * \param[in] C_lim - The model constant used for T (usually 0.6)
    */
   virtual void SetTurbScales(su2double nu,
                              su2double S,
                              su2double VelMag,
                              su2double L_inf,
-                             bool use_realizability);
+                             bool use_realizability,
+                             su2double C_lim);
 
 
   virtual void SetKolKineticEnergyRatio(su2double nu);

--- a/SU2_CFD/include/variable_structure.inl
+++ b/SU2_CFD/include/variable_structure.inl
@@ -504,7 +504,8 @@ inline void CVariable::SetTurbScales(su2double nu,
                                      su2double S,
                                      su2double VelMag,
                                      su2double L_inf,
-                                     bool use_realizability) { }
+                                     bool use_realizability,
+                                     su2double C_lim) { }
 
 inline void CVariable::SetKolKineticEnergyRatio(su2double nu) { }
 

--- a/SU2_CFD/include/variable_structure_v2f.hpp
+++ b/SU2_CFD/include/variable_structure_v2f.hpp
@@ -131,12 +131,14 @@ public:
    * \param[in] L_inf - The freestream (or problem) lengthscale
    * \param[in] use_realizability - Limit the time and lengthscales based
    *     on realizability limits on the Reynolds stress tensor.
+   * \param[in] C_lim - The model constant used for T (usually 0.6)
    */
   void SetTurbScales(su2double nu,
                      su2double S,
                      su2double VelMag,
                      su2double L_inf,
-                     bool use_realizability);
+                     bool use_realizability,
+                     su2double C_lim) override;
 
   su2double GetTypicalLengthscale(void) const;
 

--- a/SU2_CFD/src/numerics_direct_turbulent_v2f.cpp
+++ b/SU2_CFD/src/numerics_direct_turbulent_v2f.cpp
@@ -267,6 +267,7 @@ CSourcePieceWise_TurbKE::CSourcePieceWise_TurbKE(unsigned short val_nDim,
 
   /*--- Coefficient used in the C_e1 equation (usually 0.045 or 0.05) ---*/
   C_e1_factor = config->Getv2f_Ce1_Constant();
+  Rf_constant = config->Getv2f_Rf_Constant();
 
 }
 
@@ -415,16 +416,6 @@ void CSourcePieceWise_TurbKE::ComputeResidual(su2double *val_residual,
    * C_e1 -> infinity. But for channel flow at Re_tau = 5200, C_e1 < 29 for
    * all y+ > .07. So we can set a relatively low limit (e.g. 100) to enforce
    * our desired behavior. This should not affect converged solution.
-   *
-   * Additional note: Here, we use the constant 0.045, instead of 0.05.
-   * This matches the value in:
-   *
-   * Parneix, S., Durbin, P., 1997. Numerical simulation of 3D turbulent
-   * boundary layer using the v2-f model. Annual Research Briefs, Center for
-   * Turbulence Research, NASA Ames/Stanford University, 135–148
-   *
-   * This value improves converge in some cases, though it does significantly
-   * impact C_f in zero-pressure gradient boundary layers.
    * ---*/
   const su2double inv_zeta = max(tke/v2_lim, 0.5);
   const su2double C_e1 = min(C_e1o*(1.0+C_e1_factor*sqrt(inv_zeta)), 100.0);
@@ -484,7 +475,8 @@ void CSourcePieceWise_TurbKE::ComputeResidual(su2double *val_residual,
 
   su2double Rf = 1.0/TurbT;
   if (config->GetBoolUse_v2f_Rf_mod()) {
-    Rf = min(1.0/TurbT, S/(sqrt(2.0)*3.0));
+    // sqrt(2) because of sqrt(2) in S
+    Rf = min(1.0/TurbT, S/(sqrt(2.0)*Rf_constant));
   }
 
   Pf = (C_2f*Pk/(rho*tke_lim) - Rf*(C1m6*zeta - ttC1m1)) / Lsq;

--- a/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
@@ -443,6 +443,8 @@ void CTurbKESolver::Postprocessing(CGeometry *geometry,
 
   const unsigned short realizability_limit = config->GetKind_v2f_Limit();
   const bool limit_scales = (realizability_limit == T_L_LIMIT);
+  const bool limit_muT = (realizability_limit == EDDY_VISC_LIMIT);
+  const su2double C_lim = config->Getv2f_Realizability_Constant();
   for (unsigned long iPoint = 0; iPoint < nPoint; iPoint ++) {
 
     /*--- Copy over production from flow averages to turbulence variables
@@ -467,7 +469,7 @@ void CTurbKESolver::Postprocessing(CGeometry *geometry,
 
     /*--- T & L ---*/
 
-    node[iPoint]->SetTurbScales(nu, S, VelInf, L_inf, limit_scales);
+    node[iPoint]->SetTurbScales(nu, S, VelInf, L_inf, limit_scales, C_lim);
     node[iPoint]->SetKolKineticEnergyRatio(nu);
 
     const su2double Tm = node[iPoint]->GetTurbTimescale();
@@ -475,9 +477,8 @@ void CTurbKESolver::Postprocessing(CGeometry *geometry,
     /*--- Compute the eddy viscosity ---*/
 
     muT = constants[0]*rho*v2*Tm;
-    if (realizability_limit == EDDY_VISC_LIMIT) {
-      const su2double C_lim = 1.0;
-      muT = min(muT, C_lim*rho*tke/(sqrt(3)*S));
+    if (limit_muT) {
+      muT = min(muT, C_lim*rho*tke/(sqrt(3)*max(S, EPS)));
     }
 
     node[iPoint]->SetmuT(muT);
@@ -507,13 +508,14 @@ void CTurbKESolver::CalculateTurbScales(CSolver **solver_container,
 
   const bool limit_scales =
     (config->GetKind_v2f_Limit() == T_L_LIMIT);
+  const su2double C_lim = config->Getv2f_Realizability_Constant();
   for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
 
     const su2double nu  = flow_node[iPoint]->GetLaminarViscosity() /
                           flow_node[iPoint]->GetDensity();
     const su2double S   = flow_node[iPoint]->GetStrainMag();
 
-    node[iPoint]->SetTurbScales(nu, S, VelInf, L_inf, limit_scales);
+    node[iPoint]->SetTurbScales(nu, S, VelInf, L_inf, limit_scales, C_lim);
   }
 }
 

--- a/SU2_CFD/src/variable_direct_turbulent_v2f.cpp
+++ b/SU2_CFD/src/variable_direct_turbulent_v2f.cpp
@@ -104,7 +104,8 @@ void CTurbKEVariable::SetTurbScales(const su2double nu,
                                     const su2double S,
                                     const su2double VelMag,
                                     const su2double L_inf,
-                                    const bool use_realizability) {
+                                    const bool use_realizability,
+                                    const su2double C_lim) {
   /*--- Scalars ---*/
   const su2double kine = Solution[0];
   const su2double epsi = Solution[1];
@@ -131,7 +132,7 @@ void CTurbKEVariable::SetTurbScales(const su2double nu,
   kol_time     = C_T*sqrt(nu/tdr_lim);
   if (use_realizability) {
     // sqrt(3) instead of sqrt(6) because of sqrt(2) factor in S
-    stag_time    = 0.6/max(sqrt(3.0)*C_mu*S*zeta_lim, S_FLOOR);
+    stag_time    = C_lim/max(sqrt(3.0)*C_mu*S*zeta_lim, S_FLOOR);
     timescale = max(min(typical_time, stag_time), kol_time);
   } else {
     timescale = max(typical_time, kol_time);

--- a/TestCases/serial_regression.py
+++ b/TestCases/serial_regression.py
@@ -218,7 +218,7 @@ def main():
     turb_flatplate_v2f.cfg_dir   = "rans/flatplate"
     turb_flatplate_v2f.cfg_file  = "turb_v2f_flatplate.cfg"
     turb_flatplate_v2f.test_iter = 20
-    turb_flatplate_v2f.test_vals = [-0.342190, 5.330353, -0.176424, 0.057969] #last 4 columns
+    turb_flatplate_v2f.test_vals = [-0.345695, 5.326705, -0.176511, 0.057765] #last 4 columns
     turb_flatplate_v2f.su2_exec  = "SU2_CFD"
     turb_flatplate_v2f.timeout   = 1600
     turb_flatplate_v2f.tol       = 0.00001

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -135,6 +135,11 @@ USE_V2F_EXPLICIT_WALLBC= YES
 % 0.05 is value used by Lien and Kalitzin, but an earlier paper used 0.045
 % Default: 0.045
 V2F_CE1_CONSTANT= 0.045
+%
+% The constant in the numerator of the Rf mod.
+% DNS of 5200 channel data suggests this should be < 2.5 to not change
+% normal log-law behavior (Default: 3.0)
+V2F_RF_CONSTANT= 2.0
 
 % -------------------- COMPRESSIBLE FREE-STREAM DEFINITION --------------------%
 %

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1033,7 +1033,7 @@ ROE_LOW_DISSIPATION= FD
 % blending. Values below 0.005 are unstable for some simulations.
 %   0.01 was used for low-Mach channel
 %   0.04 was used for axisymmetric bump results in report (0.01 default)
-ROW_LOW_DISSIPATION_MIN= 0.01
+ROE_LOW_DISSIPATION_MIN= 0.01
 %
 % Post-reconstruction correction for low Mach number flows (NO, YES)
 LOW_MACH_CORR= NO

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -116,7 +116,7 @@ KIND_V2F_LIMIT= EDDY_VISC_LIMIT
 % The model constant used for the realizability limit in the v2-f RANS model
 % See the constant "C_lim" in Sveninngson and Davidson.
 % Sveningson and Davidson as well as Lien and Kalitzin use 0.6.
-% C_lim > 1 is the analytical result for 3D flows.
+% C_lim >= 1 is the analytical result for 3D flows.
 % For 2D-flows, 1.15 is the analytical result.
 % Default: 0.6
 V2F_REALIZABILITY_CONSTANT= 0.6
@@ -127,19 +127,19 @@ KEEP_PV2_NONNEGATIVE= YES
 % Use Rf mod in time scale in f-equation (for v2-f only) (YES, NO) Defaults to NO
 USE_V2F_RF_MOD= NO
 %
+% The constant in the numerator of the Rf mod.
+% DNS of 5200 channel data suggests this should be < 2.0 to not change
+% normal log-law behavior (Default: 1.5)
+V2F_RF_CONSTANT= 1.5
+%
 % Use 'explicit' version of v2-f wall BC (i.e., directly set solution at wall) vs.
 % incorporating BC as equation (YES, NO) Defaults to YES
 USE_V2F_EXPLICIT_WALLBC= YES
 %
 % The constant in the expression for C_eps1 (usually 0.045-0.05)
 % 0.05 is value used by Lien and Kalitzin, but an earlier paper used 0.045
-% Default: 0.045
-V2F_CE1_CONSTANT= 0.045
-%
-% The constant in the numerator of the Rf mod.
-% DNS of 5200 channel data suggests this should be < 2.5 to not change
-% normal log-law behavior (Default: 3.0)
-V2F_RF_CONSTANT= 2.0
+% Default: 0.05
+V2F_CE1_CONSTANT= 0.05
 
 % -------------------- COMPRESSIBLE FREE-STREAM DEFINITION --------------------%
 %

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -92,17 +92,6 @@ SUBGRID_ENERGY_TRANSFER_MODEL= M43
 % Use the resolved turbulent stress for model-split hybrid RANS/LES (NO, YES)
 USE_RESOLVED_TURB_STRESS= YES
 %
-% For the v2-f RANS model, limit the timescale in the f-equation to 3/S,
-% where S is the Frobenius norm of the mean rate-of-strain tensor. (NO, YES)
-V2F_TIMESCALE_LIMIT= NO
-%
-% The kind of realizability constraint imposed for the v2-f RANS model.
-% (EDDY_VISC_LIMIT, T_L_LIMIT)
-KIND_V2F_LIMIT= EDDY_VISC_LIMIT
-%
-% Limit the production of v2 to non-negative values for the v2-f RANS model.
-KEEP_PV2_NONNEGATIVE= YES
-%
 % The damping that will be applied to the fluctuating stress for high
 % aspect-ratio cells (NONE, BLEND_STRESS_TO_ZERO, BLEND_STRESS_TO_RANS)
 FLUCT_STRESS_DAMPING= BLEND_STRESS_TO_ZERO
@@ -116,6 +105,36 @@ FLUCT_STRESS_DAMPING= BLEND_STRESS_TO_ZERO
 % the aspect ratio, taken at the threshold.
 % Default: (128, 0.03125)
 FLUCT_STRESS_AR_PARAM= (128, 0.03125)
+
+
+% ----------------------------- V2F OPTIONS -----------------------------------%
+%
+% The kind of realizability constraint imposed for the v2-f RANS model.
+% (EDDY_VISC_LIMIT, T_L_LIMIT)
+KIND_V2F_LIMIT= EDDY_VISC_LIMIT
+%
+% The model constant used for the realizability limit in the v2-f RANS model
+% See the constant "C_lim" in Sveninngson and Davidson.
+% Sveningson and Davidson as well as Lien and Kalitzin use 0.6.
+% C_lim > 1 is the analytical result for 3D flows.
+% For 2D-flows, 1.15 is the analytical result.
+% Default: 0.6
+V2F_REALIZABILITY_CONSTANT= 0.6
+%
+% Limit the production of v2 to non-negative values for the v2-f RANS model.
+KEEP_PV2_NONNEGATIVE= YES
+%
+% Use Rf mod in time scale in f-equation (for v2-f only) (YES, NO) Defaults to NO
+USE_V2F_RF_MOD= NO
+%
+% Use 'explicit' version of v2-f wall BC (i.e., directly set solution at wall) vs.
+% incorporating BC as equation (YES, NO) Defaults to YES
+USE_V2F_EXPLICIT_WALLBC= YES
+%
+% The constant in the expression for C_eps1 (usually 0.045-0.05)
+% 0.05 is value used by Lien and Kalitzin, but an earlier paper used 0.045
+% Default: 0.045
+V2F_CE1_CONSTANT= 0.045
 
 % -------------------- COMPRESSIBLE FREE-STREAM DEFINITION --------------------%
 %
@@ -908,21 +927,6 @@ SLOPE_LIMITER_TURB= VENKATAKRISHNAN
 %
 % Use -(2/3)*rho*tke*div(u) in TKE production? (YES, NO) Defaults to YES
 DIVU_IN_TKE_PRODUCTION= YES
-%
-% Use Rf mod in time scale in f-equation (for v2-f only) (YES, NO) Defaults to NO
-USE_V2F_RF_MOD= NO
-%
-% Use 'explicit' version of v2-f wall BC (i.e., directly set solution at wall) vs.
-% incorporating BC as equation (YES, NO) Defaults to YES
-USE_V2F_EXPLICIT_WALLBC= YES
-%
-% The kind of realizability constraint imposed for the v2-f RANS model.
-% (NONE, EDDY_VISC_LIMIT, T_L_LIMIT) Default: EDDY_VISC_LIMIT
-KIND_V2F_LIMIT= EDDY_VISC_LIMIT
-%
-% The model constant used for the realizability limit in the v2-f RANS model
-% See the constant "C_lim" in Sveninngson and Davidson.  Default: 0.6
-V2F_REALIZABILITY_CONSTANT= 0.6
 %
 % Monotonic Upwind Scheme for Conservation Laws (TVD) in the adjoint flow equations.
 %           Required for 2nd order upwind schemes (NO, YES)


### PR DESCRIPTION
Several issues have been identified with the implementation of the v2-f model:

+ The constant in the C_e1 expression was previously 0.045, but in Lien and Kalitzin it was 0.05.  This is now a user-adjustable constant.
+ The Rf limiter was found to affect converged RANS behavior in the log-law region.  This limiter is left in, but it now features a user-adjustable constant to scale back the limit.
+ A user-tunable constant has been re-introduced to the realizability constraints on eddy viscosity and T, L, in line with the paper by Sveningsdon and Davidson.