### PR TITLE
Add workarounds for bug present with periodic boundaries, large grids, and MPI

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -804,6 +804,7 @@ private:
   Wrt_InletFile,                   /*!< \brief Write a template inlet profile file */
   Wrt_Slice,                   /*!< \brief Write 1D slice of a 2D cartesian solution */
   Wrt_Projected_Sensitivity,   /*!< \brief Write projected sensitivities (dJ/dx) on surfaces to ASCII file. */
+  Wrt_Partition,               /*!< \brief Write the partition (coloring) to the output */
   Plot_Section_Forces;       /*!< \brief Write sectional forces for specified markers. */
   unsigned short Console_Output_Verb,  /*!< \brief Level of verbosity for console output */
   Kind_Average;        /*!< \brief Particular average for the marker analyze. */
@@ -9622,6 +9623,12 @@ public:
   void SetWrt_InvalidState(bool invalid_state) { Wrt_InvalidState = invalid_state; };
 
   unsigned short GetSliceRestartType(void) const { return SliceRestartType; }
+  
+  /*!
+   * \brief Check if the partition (coloring) should be an output
+   * \return YES if the partition (coloring) should be written
+   */
+  bool GetWrt_Partition(void) const { return Wrt_Partition; }
 };
 
 #include "config_structure.inl"

--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -1038,7 +1038,9 @@ private:
   bool addCrossTerm;          /*!< \brief Evaluates the need to add the cross term when setting the adjoint output. */
   unsigned long Nonphys_Points, /*!< \brief Current number of non-physical points in the solution. */
   Nonphys_Reconstr;      /*!< \brief Current number of non-physical reconstructions for 2nd-order upwinding. */
-  bool ParMETIS;      /*!< \brief Boolean for activating ParMETIS mode (while testing). */
+  su2double ParMETIS_tolerance;     /*!< \brief Load balancing tolerance for ParMETIS. */
+  long ParMETIS_pointWgt;           /*!< \brief Load balancing weight given to points. */
+  long ParMETIS_edgeWgt;            /*!< \brief Load balancing weight given to edges. */
   unsigned short DirectDiff; /*!< \brief Direct Differentation mode. */
   bool DiscreteAdjoint; /*!< \brief AD-based discrete adjoint mode. */
   unsigned long Wrt_Surf_Freq_DualTime;	/*!< \brief Writing surface solution frequency for Dual Time. */
@@ -9629,6 +9631,21 @@ public:
    * \return YES if the partition (coloring) should be written
    */
   bool GetWrt_Partition(void) const { return Wrt_Partition; }
+
+  /*!
+   * \brief Get the ParMETIS load balancing tolerance.
+   */
+  passivedouble GetParMETIS_Tolerance() const { return SU2_TYPE::GetValue(ParMETIS_tolerance); }
+
+  /*!
+   * \brief Get the ParMETIS load balancing weight for points.
+   */
+  long GetParMETIS_PointWeight() const { return ParMETIS_pointWgt; }
+
+  /*!
+   * \brief Get the ParMETIS load balancing weight for edges
+   */
+  long GetParMETIS_EdgeWeight() const { return ParMETIS_edgeWgt; }
 };
 
 #include "config_structure.inl"

--- a/Common/include/geometry_structure.hpp
+++ b/Common/include/geometry_structure.hpp
@@ -359,16 +359,14 @@ public:
   
   /*--- Partitioning-specific variables ---*/
   map<unsigned long,unsigned long> Global_to_Local_Elem;
-  unsigned long xadj_size;
-  unsigned long adjacency_size;
   unsigned long *starting_node;
   unsigned long *ending_node;
   unsigned long *npoint_procs;
   unsigned long *nPoint_Linear;
 #ifdef HAVE_MPI
 #ifdef HAVE_PARMETIS
-  idx_t * adjacency;
-  idx_t * xadj;
+  std::vector<idx_t> adjacency;
+  std::vector<idx_t> xadj;
 #endif
 #endif
   

--- a/Common/include/geometry_structure.hpp
+++ b/Common/include/geometry_structure.hpp
@@ -929,7 +929,7 @@ public:
     */
    virtual void Set_MPI_Coord(CConfig *config);
 
-   virtual void Set_MPI_Resolution_Tensor(CConfig *config);
+   virtual void Set_MPI_Resolution_Tensor(CConfig *config, int sendrecv_tag=0);
 
    /*!
     * \brief A virtual member.
@@ -2155,7 +2155,7 @@ void UpdateTurboVertex(CConfig *config,unsigned short val_iZone, unsigned short 
    */
   void Set_MPI_Coord(CConfig *config);
 
-  void Set_MPI_Resolution_Tensor(CConfig *config);
+  void Set_MPI_Resolution_Tensor(CConfig *config, int sendrecv_tag=0) override;
   
   /*!
    * \brief Perform the MPI communication for the grid velocities.

--- a/Common/include/geometry_structure.inl
+++ b/Common/include/geometry_structure.inl
@@ -141,7 +141,7 @@ inline void CGeometry::SetRestricted_GridVelocity(CGeometry *fine_mesh, CConfig 
 
 inline void CGeometry::Set_MPI_Coord(CConfig *config) { } 
 
-inline void CGeometry::Set_MPI_Resolution_Tensor(CConfig *config) { }
+inline void CGeometry::Set_MPI_Resolution_Tensor(CConfig *config, int sendrecv_tag) { }
 
 inline void CGeometry::Set_MPI_GridVel(CConfig *config) { } 
 

--- a/Common/include/mpi_structure.inl
+++ b/Common/include/mpi_structure.inl
@@ -44,6 +44,9 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
   /* Set MinRankError to Rank, as the error message is called on this rank. */
   MinRankError = Rank;
   int flag = 0;
+  /* Wait a relatively long time. It is better to exit gracefully but slowly
+   * than crash prematurely. */
+  constexpr double delay_time = 15.0;
 
 #if MPI_VERSION >= 3
   /* Find out whether the error call is collective via MPI_Ibarrier. */
@@ -58,12 +61,12 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
     if( flag ) break;
 
     double currentTime = MPI_Wtime();
-    if(currentTime > startTime + 1.0) break;
+    if(currentTime > startTime + delay_time) break;
   }
 #else
   /* MPI_Ibarrier function is not supported. Simply wait for one
      second to give other ranks the opportunity to reach this point. */
-  sleep(1);
+  sleep(delay_time);
 #endif
 
   if( flag ) {
@@ -98,6 +101,8 @@ inline void CBaseMPIWrapper::Error(std::string ErrorMsg, std::string FunctionNam
     std::cout <<  "------------------------------ Error Exit -------------------------------" << std::endl;
     std::cout << std::endl << std::endl;    
   }
+  /* Give time for the message to flush to the screen. */
+  sleep(5);
   Abort(currentComm, EXIT_FAILURE);
 }
 

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -2465,8 +2465,14 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   /* DESCRIPTION: Number of zones of the problem */
   addPythonOption("NZONES");
 
-  /* DESCRIPTION: Activate ParMETIS mode for testing */
-  addBoolOption("PARMETIS", ParMETIS, false);
+  /* DESCRIPTION: ParMETIS load balancing tolerance */
+  addDoubleOption("PARMETIS_TOLERANCE", ParMETIS_tolerance, 0.05);
+
+  /* DESCRIPTION: ParMETIS load balancing weight for points */
+  addLongOption("PARMETIS_POINT_WEIGHT", ParMETIS_pointWgt, 1);
+
+  /* DESCRIPTION: ParMETIS load balancing weight for edges (equiv. to neighbors) */
+  addLongOption("PARMETIS_EDGE_WEIGHT", ParMETIS_edgeWgt, 0);
     
   /*--- options that are used in the Hybrid RANS/LES Simulations  ---*/
   /*!\par CONFIG_CATEGORY:Hybrid_RANSLES Options\ingroup Config*/

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -2556,6 +2556,10 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
 
   addEnumOption("SLICE_RESTART_TYPE", SliceRestartType, SliceRestartType_Map, NO_SLICE_RESTART);
 
+  /*!\brief WRT_PARTITION \n DESCRIPTION: Write the paritition (color) of
+    each node \n DEFAULT: False \ingroup Config */
+  addBoolOption("WRT_PARTITION", Wrt_Partition, false);
+
   /* END_CONFIG_OPTIONS */
 
 }

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -8915,10 +8915,13 @@ void CPhysicalGeometry::SetBoundaries(CConfig *config) {
   nMarker_SendRecv = nMarker - nMarker_Physical - Duplicate_SendReceive;
   if (nMarker_SendRecv % 2 > 0) {
     std::stringstream error_msg;
+    error_msg << "-------------------------------------------------------------" << endl;
     error_msg << "Send/Recv markers should have been set up in pairs.\n";
     error_msg << "Instead of an even number of Send/Recv markers, found ";
     error_msg << nMarker_SendRecv << " Send/Recv\nmarkers on rank " << rank << "\n";
-    SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+    error_msg << "-------------------------------------------------------------" << endl;
+    cout << error_msg.str();
+    // SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
   }
   bound_Copy = new CPrimalGrid**[nMarker_Physical + nMarker_SendRecv];
   nElem_Bound_Copy = new unsigned long [nMarker_Physical + nMarker_SendRecv];
@@ -17887,40 +17890,46 @@ void CPhysicalGeometry::Set_MPI_Resolution_Tensor(CConfig *config, int sendrecv_
 #endif
 
       if (MarkerR >= nMarker) {
-         error_msg << "The partitioning failed!" << endl;
-         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
-         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         if (!throw_error) {
+           error_msg << "The partitioning failed!" << endl;
+           error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         }
+         error_msg << "SU2 encountered MarkerR > nMarker." << endl;
          error_msg << "  rank :    " << rank << endl;
          error_msg << "  nMarker : " << nMarker << endl;
          error_msg << "  MarkerS : " << MarkerS << endl;
          error_msg << "  MarkerR : " << MarkerR << endl;
-
          throw_error = true;
-         break;
-      } else if (config->GetMarker_All_KindBC(MarkerR) != SEND_RECEIVE) {
-         error_msg << "The partitioning failed!" << endl;
-         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
-         error_msg << "  Instead, SU2 found MarkerR that was not SEND_RECEIVE." << endl;
+      }
+      if (config->GetMarker_All_KindBC(MarkerR) != SEND_RECEIVE) {
+         if (!throw_error) {
+           error_msg << "The partitioning failed!" << endl;
+           error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         }
+         error_msg << "SU2 found MarkerR that was not SEND_RECEIVE." << endl;
          error_msg << "  Note: (SEND_RECEIVE == 99)" << endl;
          error_msg << "  rank:            " << rank << endl;
          error_msg << "  MarkerS :        " << MarkerS << endl;
          error_msg << "  MarkerR:         " << MarkerR << endl;
          error_msg << "  KindBC[MarkerR]: " << config->GetMarker_All_KindBC(MarkerR) << endl;
          throw_error = true;
-         break;
-      } else if (-config->GetMarker_All_SendRecv(MarkerR) !=
-                 config->GetMarker_All_SendRecv(MarkerS)) {
-         error_msg << "The partitioning failed!" << endl;
-         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
-         error_msg << "  Instead, SU2 found MarkerR that did not match MarkerS." << endl;
+      }
+      if (-config->GetMarker_All_SendRecv(MarkerR) !=
+           config->GetMarker_All_SendRecv(MarkerS)) {
+         if (!throw_error) {
+           error_msg << "The partitioning failed!" << endl;
+           error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         }
+         error_msg << "SU2 found MarkerR that did not match MarkerS." << endl;
          error_msg << "  rank:              " << rank << endl;
          error_msg << "  MarkerS:           " << MarkerS << endl;
          error_msg << "  MarkerR:           " << MarkerR << endl;
          error_msg << "  SendRecv[MarkerS]: " << config->GetMarker_All_SendRecv(MarkerS) << endl;
          error_msg << "  SendRecv[MarkerR]: " << config->GetMarker_All_SendRecv(MarkerR) << endl;
          throw_error = true;
-         break;
       }
+      if (throw_error) break;
+
       nVertexS = nVertex[MarkerS];
       nVertexR = nVertex[MarkerR];
 

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -4673,6 +4673,7 @@ CPhysicalGeometry::CPhysicalGeometry(CGeometry *geometry, CConfig *config) {
                     assert(iVertex < geometry->GetnElem_Bound(jMarker));
                     jPoint = geometry->bound[jMarker][iVertex]->GetNode(0);
                     ReceptorColor = local_colour_values[jPoint];
+                    receptor_flags[ReceptorColor] = 1;
                   }
                 }
                 
@@ -17393,8 +17394,9 @@ void CPhysicalGeometry::SetColorGrid_Parallel(CConfig *config) {
   
   /*--- Initialize the color vector ---*/
   
-  for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++)
+  for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
     node[iPoint]->SetColor(0);
+  }
   
   /*--- This routine should only ever be called if we have parallel support
    with MPI and have the ParMETIS library compiled and linked. ---*/
@@ -17402,7 +17404,6 @@ void CPhysicalGeometry::SetColorGrid_Parallel(CConfig *config) {
 #ifdef HAVE_MPI
 #ifdef HAVE_PARMETIS
   
-  unsigned long iPoint;
   MPI_Comm comm = MPI_COMM_WORLD;
 
   /*--- Only call ParMETIS if we have more than one rank to avoid errors ---*/
@@ -17499,7 +17500,7 @@ void CPhysicalGeometry::SetColorGrid_Parallel(CConfig *config) {
      since each processor is calling ParMETIS in parallel and storing the
      results for its initial piece of the grid. ---*/
     
-    for (iPoint = 0; iPoint < nPoint; iPoint++) {
+    for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
       assert(part[iPoint] < size);
       node[iPoint]->SetColor(part[iPoint]);
     }

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -2899,7 +2899,7 @@ CPhysicalGeometry::CPhysicalGeometry(CGeometry *geometry, CConfig *config) {
   unsigned long local_max_color = 0;
   unsigned long local_min_color = size;
   for (unsigned long i=0; i<local_width; i++) {
-    assert(i < geometry->GetnPoint());
+    assert(i < val_Global_nPoint);
     assert(geometry->starting_node[rank]+i < val_Global_nPoint);
     local_colour_temp[i]=geometry->node[i]->GetColor();
     local_max_color = max(local_max_color, local_colour_temp[i]);
@@ -2929,25 +2929,22 @@ CPhysicalGeometry::CPhysicalGeometry(CGeometry *geometry, CConfig *config) {
   int comm_counter=0;
   for (iDomain=0; iDomain < (unsigned long)size; iDomain++) {
     if (iDomain != (unsigned long)rank) {
-      // assert(comm_counter < offset + size);
-      // assert(geometry->ending_node[rank]-geometry->starting_node[rank] > 0);
+      assert(geometry->ending_node[rank] - geometry->starting_node[rank] > 0);
       SU2_MPI::Isend(local_colour_temp, geometry->ending_node[rank]-geometry->starting_node[rank],
                      MPI_UNSIGNED_LONG, iDomain, iDomain,  MPI_COMM_WORLD, &send_req[comm_counter]);
       comm_counter++;
     }
   }
-  // assert(size-1 == comm_counter);
+  assert(size-1 == comm_counter);
   
   for (iDomain=0; iDomain < (unsigned long)size-1; iDomain++) {
     SU2_MPI::Probe(MPI_ANY_SOURCE, rank, MPI_COMM_WORLD, &status2);
     source = status2.MPI_SOURCE;
-    // assert(source != rank);
-    // assert(source < size);
+    assert(source != rank);
+    assert(source < size);
     SU2_MPI::Get_count(&status2, MPI_UNSIGNED_LONG, &recv_count);
-    // assert(recv_count > 0);
-    // assert(starting_node[source] >= 0);
-    // assert(starting_node[source] + recv_count == ending_node[source]); 
-    // assert(starting_node[source] + recv_count <= val_Global_nPoint);
+    assert(recv_count >= 0);
+    assert(geometry->starting_node[source] + recv_count <= val_Global_nPoint);
     SU2_MPI::Recv(&local_colour_values[geometry->starting_node[source]], recv_count,
                   MPI_UNSIGNED_LONG, source, rank, MPI_COMM_WORLD, &status2);
   }
@@ -4704,7 +4701,7 @@ CPhysicalGeometry::CPhysicalGeometry(CGeometry *geometry, CConfig *config) {
         }
       }
 
-      bool found_error = false;;
+      bool found_error = false;
       std::ostringstream err_msg;
       for (std::size_t i = 0; i < donor_flags.size(); ++i) {
         if (donor_flags[i] > 0 && receptor_flags[i] == 0) {
@@ -8667,7 +8664,6 @@ void CPhysicalGeometry::SetSendReceive(CConfig *config) {
   
   SendDomainLocal.resize(nDomain);
   ReceivedDomainLocal.resize(nDomain);
-
 
   /*--- Loop over the all the points of the elements on this rank in order
    to find the points with different colors. Create the send/received lists
@@ -17419,7 +17415,7 @@ void CPhysicalGeometry::SetColorGrid_Parallel(CConfig *config) {
   // Sanity checks on the number of neighbors
   for (unsigned long iPoint = 0; iPoint < nPoint; iPoint++) {
     auto local_n_neighbors = (xadj[iPoint+1] - xadj[iPoint]);
-    assert(local_n_neighbors >= 0);
+    assert(local_n_neighbors > 0);
     assert(local_n_neighbors <= 12);
   }
 #endif

--- a/Common/src/geometry_structure.cpp
+++ b/Common/src/geometry_structure.cpp
@@ -19314,7 +19314,7 @@ void CPhysicalGeometry::SetSensitivity(CConfig *config) {
     for (iPoint_Global = 0; iPoint_Global < GetGlobal_nPointDomain(); iPoint_Global++ ) {
       if (GetGlobal_to_Local_Point(iPoint_Global) > -1) {
         blocklen[counter] = nFields;
-        displace[counter] = iPoint_Global*nFields*sizeof(passivedouble)
+        displace[counter] = iPoint_Global*nFields*sizeof(passivedouble);
         counter++;
       }
     }

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -1010,6 +1010,10 @@ void CDriver::Geometrical_Preprocessing() {
       geometry_container[iZone][iInst][MESH_0]->SetControlVolume(config_container[iZone], ALLOCATE);
       geometry_container[iZone][iInst][MESH_0]->SetBoundControlVolume(config_container[iZone], ALLOCATE);
 
+#ifdef HAVE_MPI
+      SU2_MPI::Barrier(MPI_COMM_WORLD);
+#endif
+
       /*--- Compute the max length. ---*/
 
       if ((config_container[iZone]->GetKind_RoeLowDiss() != NO_ROELOWDISS) ||
@@ -1018,6 +1022,9 @@ void CDriver::Geometrical_Preprocessing() {
         geometry_container[iZone][iInst][MESH_0]->SetMaxLength(config_container[iZone]);
       }
 
+#ifdef HAVE_MPI
+      SU2_MPI::Barrier(MPI_COMM_WORLD);
+#endif
       /*--- Compute cell resolution tensors ---*/
 
       if (config_container[iZone]->GetKind_HybridRANSLES() == MODEL_SPLIT ||

--- a/SU2_CFD/src/output_tecplot.cpp
+++ b/SU2_CFD/src/output_tecplot.cpp
@@ -213,6 +213,10 @@ void COutput::SetTecplotASCII(CConfig *config, CGeometry *geometry, CSolver **so
           Tecplot_File << ", \"Sharp_Edge_Dist\"";
         }
       }
+
+      if (config->GetWrt_Partition()) {
+        Tecplot_File << ", \"Partition\"";
+      }
       
       if (( Kind_Solver == ADJ_EULER              ) ||
           ( Kind_Solver == ADJ_NAVIER_STOKES      ) ||
@@ -3577,6 +3581,11 @@ string COutput::AssembleVariableNames(CGeometry *geometry, CConfig *config, unsi
         variables << "Sharp_Edge_Dist ";
         *NVar += 1;
       }
+    }
+
+    if (config->GetWrt_Partition()) {
+      variables << "Partition ";
+      *NVar += 1;
     }
     
 

--- a/SU2_CFD/src/solver_direct_mean.cpp
+++ b/SU2_CFD/src/solver_direct_mean.cpp
@@ -1595,7 +1595,17 @@ void CEulerSolver::Set_MPI_Solution(CGeometry *geometry, CConfig *config) {
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
-      
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
+
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
       receive_from = abs(config->GetMarker_All_SendRecv(MarkerR))-1;
@@ -1715,6 +1725,16 @@ void CEulerSolver::Set_MPI_Average_Solution(CGeometry *geometry, CConfig *config
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
 
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
 
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -1898,6 +1918,16 @@ void CEulerSolver::Set_MPI_Solution_Old(CGeometry *geometry, CConfig *config) {
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2014,6 +2044,16 @@ void CEulerSolver::Set_MPI_Undivided_Laplacian(CGeometry *geometry, CConfig *con
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2130,6 +2170,16 @@ void CEulerSolver::Set_MPI_MaxEigenvalue(CGeometry *geometry, CConfig *config) {
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2209,6 +2259,16 @@ void CEulerSolver::Set_MPI_Sensor(CGeometry *geometry, CConfig *config) {
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2288,6 +2348,16 @@ void CEulerSolver::Set_MPI_Solution_Gradient(CGeometry *geometry, CConfig *confi
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2447,6 +2517,16 @@ void CEulerSolver::Set_MPI_Average_Solution_Gradient(CGeometry *geometry, CConfi
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
 
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
 
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2600,6 +2680,16 @@ void CEulerSolver::Set_MPI_Solution_Limiter(CGeometry *geometry, CConfig *config
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2727,6 +2817,16 @@ void CEulerSolver::Set_MPI_Primitive_Gradient(CGeometry *geometry, CConfig *conf
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -2893,6 +2993,16 @@ void CEulerSolver::Set_MPI_Average_Primitive_Gradient(CGeometry *geometry, CConf
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
 
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
 
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -3054,6 +3164,16 @@ void CEulerSolver::Set_MPI_Primitive_Limiter(CGeometry *geometry, CConfig *confi
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= nMarker) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << nMarker << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -111,6 +111,16 @@ void CTurbSolver::Set_MPI_Solution(CGeometry *geometry, CConfig *config) {
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= config->GetnMarker_All()) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << config->GetnMarker_All() << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -198,6 +208,16 @@ void CTurbSolver::Set_MPI_Average_Solution(CGeometry *geometry, CConfig *config)
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
 
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= config->GetnMarker_All()) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << config->GetnMarker_All() << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
 
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -285,6 +305,16 @@ void CTurbSolver::Set_MPI_Solution_Old(CGeometry *geometry, CConfig *config) {
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= config->GetnMarker_All()) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << config->GetnMarker_All() << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -364,6 +394,16 @@ void CTurbSolver::Set_MPI_Solution_Gradient(CGeometry *geometry, CConfig *config
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= config->GetnMarker_All()) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << config->GetnMarker_All() << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;
@@ -483,6 +523,16 @@ void CTurbSolver::Set_MPI_Solution_Limiter(CGeometry *geometry, CConfig *config)
         (config->GetMarker_All_SendRecv(iMarker) > 0)) {
       
       MarkerS = iMarker;  MarkerR = iMarker+1;
+      if (MarkerR >= config->GetnMarker_All()) {
+         std::stringstream error_msg;
+         error_msg << "Expected send/receive to marker pairs to be sequential." << endl;
+         error_msg << "  Instead, SU2 encountered MarkerR > nMarker." << endl;
+         error_msg << "  rank :    " << rank << endl;
+         error_msg << "  nMarker : " << config->GetnMarker_All() << endl;
+         error_msg << "  MarkerR : " << MarkerR << endl;
+         error_msg << "  MarkerS : " << MarkerS << endl;
+         SU2_MPI::Error(error_msg.str(), CURRENT_FUNCTION);
+      }
       
 #ifdef HAVE_MPI
       send_to = config->GetMarker_All_SendRecv(MarkerS)-1;

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -2527,7 +2527,7 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, CConfig *config, stri
   for (iPoint_Global = 0; iPoint_Global < geometry->GetGlobal_nPointDomain(); iPoint_Global++ ) {
     if (geometry->GetGlobal_to_Local_Point(iPoint_Global) > -1) {
       blocklen[counter] = nFields;
-      displace[counter] = iPoint_Global*nFields*sizeof(passivedouble)
+      displace[counter] = iPoint_Global*nFields*sizeof(passivedouble);
       counter++;
     }
   }

--- a/SU2_CFD/src/solver_structure.cpp
+++ b/SU2_CFD/src/solver_structure.cpp
@@ -2522,16 +2522,16 @@ void CSolver::Read_SU2_Restart_Binary(CGeometry *geometry, CConfig *config, stri
    points which are distributed throughout the file in blocks of nVar_Restart data. ---*/
 
   int *blocklen = new int[geometry->GetnPointDomain()];
-  int *displace = new int[geometry->GetnPointDomain()];
+  MPI_Aint *displace = new MPI_Aint[geometry->GetnPointDomain()];
   int counter = 0;
   for (iPoint_Global = 0; iPoint_Global < geometry->GetGlobal_nPointDomain(); iPoint_Global++ ) {
     if (geometry->GetGlobal_to_Local_Point(iPoint_Global) > -1) {
       blocklen[counter] = nFields;
-      displace[counter] = iPoint_Global*nFields;
+      displace[counter] = iPoint_Global*nFields*sizeof(passivedouble)
       counter++;
     }
   }
-  MPI_Type_indexed(geometry->GetnPointDomain(), blocklen, displace, MPI_DOUBLE, &filetype);
+  MPI_Type_create_hindexed(geometry->GetnPointDomain(), blocklen, displace, MPI_DOUBLE, &filetype);
   MPI_Type_commit(&filetype);
 
   /*--- Set the view for the MPI file write, i.e., describe the location in

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1389,6 +1389,23 @@ UQ_URLX= 0.1
 % Perturbation magnitude (float [0,1], default= 1.0)
 UQ_DELTA_B= 1.0
 
+% ----------------------- PARTITIONING OPTIONS (ParMETIS) -------------------- %
+%
+% Load balancing tolerance, lower values will make ParMETIS work harder to
+% evenly distribute the work-estimate metric across all MPI ranks, at the
+% expense of more edge cuts (i.e. increased communication cost).
+PARMETIS_TOLERANCE= 0.02
+%
+% The work-estimate metric is a weighted function of the work-per-edge (e.g.
+% spatial discretization, linear system solution) and of the work-per-point
+% (e.g. source terms, temporal discretization) the former usually accounts
+% for >90% of the total. These weights are INTEGERS (for compatibility with
+% ParMETIS) thus not [0, 1]. To balance memory usage (instead of computation)
+% the point weight needs to be increased (especially for explicit time
+% integration methods).
+PARMETIS_EDGE_WEIGHT= 1
+PARMETIS_POINT_WEIGHT= 0
+
 % ------------------------- INPUT/OUTPUT INFORMATION --------------------------%
 %
 % Mesh input file


### PR DESCRIPTION
This is an attempt to work-around some issues in [su2code's Issue #550](https://github.com/su2code/SU2/issues/550) and our issue #24.  This issue was also noticed by Beckett Zhou. Basically, the program will segfault when the number of ranks relatively high.  The exact number of MPI ranks is problem-dependent, but I've observed the error on the low-Mach channel, the high-Mach channel, and the axisymmetric bump problem.

This bug has only been noticed when all three of these factors are in play:

1. Periodic boundaries
2. Larger grids (> 1 million nodes)
3. Higher number of MPI ranks (> 50, but also problem dependent)

Dropping to a lower number of MPI ranks usually prevents the error, for unknown reasons.

## Symptoms and Source

The typical symptom is that a send/recv fails somewhere in the MPI communication, usually due to either a buffer mismatch or a send/recv left hanging with no response.  This can lead to a deadlock during an MPI communication pattern.  If you're lucky, the MPI routines will try to query information for a non-existent partition, and you'll get a simple segfault instead of a failed MPI call.

I've been unable to isolate the exact source of the bug.  Running Valgrind and Allinea's DDT did not show any typical memory errors (out-of-bounds array access, memory exhaustion, etc).  The compiler generates no warnings for this section of code. I haven't been able to find any "magic numbers" or `short` integer overflows. This seems to be a problem of *assumptions* rather than *incorrect code*. If I am not mistaken, some (still unknown) assumption is made when setting up periodic boundaries and then partitioning those boundaries.  The bug happens when this assumption is violated.

I've tracked down much clearer symptoms. The earliest known manifestation is when setting up the partitioning for the periodic boundaries.  This is in the constructor `CPhysicalGeometry::CPhysicalGeometry(CGeometry* geometry, CConfig* config)`.  The partitioning and the original periodic boundary construction appear to be correct.  But the send/recv pairs do not line up after partitioning the periodic boundaries.  This symptom is easy to diagnose, since you can check the send/recv pairs to make sure they match.

This bug happens *before* the send/recv between partitions are set up (in `SetSendRecv` and `SetBoundaries`).  The send/recv pairs between partitions seem to be set up correctly.  The bug originates in the partitioning of the periodic boundaries. It seems like the correct halo nodes for some of the interior cells are not constructed properly.

##  What has upstream done about this?

The upstream branch (su2code/SU2) has completely changed the periodic boundary implementation.  Beckett Zhou believes this bug is gone in the upstream branch.  I have not verified this myself.  There are several existing issues with the new periodic boundary implementation (see issues https://github.com/su2code/SU2/issues/1090 and https://github.com/su2code/SU2/issues/763).  This has kept us from pulling from upstream.  The current paradigm is "better the devil you know than the devil you don't."

## What are we doing about this?

I've added in a large set of checks to verify the send/recv pairs are set up correctly, and to make sure that ParMETIS has valid inputs.  Only the former may be necessary.  These checks will catch the bug and exit gracefully, before a program crash or MPI deadlock.

I've also added some of the changes from upstream. These changes allow the user to tweak the partitioning through the cfg file options.  For at least one test case so far, this allows the user to work around the bug.

Overall, the lack of a clear source for this bug is disappointing and unsettling.  But debugging a 2,500 line constructor is no simple task, and I've already wasted a lot of time in dead-ends.