### PR TITLE
Fix the missing override in SST lengthscales

### DIFF
--- a/SU2_CFD/include/variable_structure.hpp
+++ b/SU2_CFD/include/variable_structure.hpp
@@ -1252,8 +1252,8 @@ public:
                              su2double S,
                              su2double VelMag,
                              su2double L_inf,
-                             bool use_realizability,
-                             su2double C_lim);
+                             bool use_realizability=false,
+                             su2double C_lim=0.0);
 
 
   virtual void SetKolKineticEnergyRatio(su2double nu);
@@ -4823,8 +4823,12 @@ public:
    * \param[in] use_realizability - Limit the time and lengthscales based
    *     on realizability limits on the Reynolds stress tensor.
    */
-  void SetTurbScales(su2double nu, su2double S, su2double VelMag,
-                     su2double L_inf, bool use_realizability);
+  void SetTurbScales(su2double nu,
+                     su2double S,
+                     su2double VelMag,
+                     su2double L_inf,
+                     bool use_realizability=false,
+                     su2double C_lim=0.0) override;
 
   /*!
    * \brief Set the production of turbulent kinetic energy.

--- a/SU2_CFD/include/variable_structure_v2f.hpp
+++ b/SU2_CFD/include/variable_structure_v2f.hpp
@@ -137,8 +137,8 @@ public:
                      su2double S,
                      su2double VelMag,
                      su2double L_inf,
-                     bool use_realizability,
-                     su2double C_lim) override;
+                     bool use_realizability=false,
+                     su2double C_lim=0.0) override;
 
   su2double GetTypicalLengthscale(void) const;
 

--- a/SU2_CFD/src/solver_direct_turbulent.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent.cpp
@@ -4340,8 +4340,8 @@ void CTurbSSTSolver::Postprocessing(CGeometry *geometry, CSolver **solver_contai
 
     /*--- We use SetTurbScales instead of manually setting T, L so
      * we can set kolmogorov scales too --*/
-    // Note: strMag and Clim is not actually used SST function
-    node[iPoint]->SetTurbScales(nu, 0.0, VelMag, L_inf, false, 0.0);
+    // Note: strMag is not actually used SST function
+    node[iPoint]->SetTurbScales(nu, 0.0, VelMag, L_inf);
 
     /*--- Compute anisotropy measure ---*/
     const su2double C_mu_v2f = 0.22;
@@ -4381,7 +4381,7 @@ void CTurbSSTSolver::CalculateTurbScales(CSolver **solver_container,
                           flow_node[iPoint]->GetDensity();
     const su2double S   = flow_node[iPoint]->GetStrainMag();
 
-    node[iPoint]->SetTurbScales(nu, S, VelMag, L_inf, false, 0.0);
+    node[iPoint]->SetTurbScales(nu, S, VelMag, L_inf);
   }
 }
 

--- a/SU2_CFD/src/variable_direct_turbulent.cpp
+++ b/SU2_CFD/src/variable_direct_turbulent.cpp
@@ -273,10 +273,16 @@ void CTurbSSTVariable::SetTurbScales(const su2double nu,
                                     const su2double S,
                                     const su2double VelMag,
                                     const su2double L_inf,
-                                    const bool use_realizability) {
+                                    const bool use_realizability,
+                                    const su2double C_lim) {
+  /*--- Stagnation point limiters aren't typically used for SST scales,
+   * since the production limiter and shear stress limiter are used instead.
+   * ---*/
+  assert(not(use_realizability));
 
-  /*--- Remember, omega := epsilon / (C_mu * k) . The C_mu is important if
-   * you're going to be comparing k-epsilon type models with SST ---*/
+  /*--- Remember, omega := epsilon / (C_mu * k) . The C_mu (or
+   * equivalently beta*) is important if you're going to be comparing
+   * k-epsilon type models with SST ---*/
 
   /*--- Wilcox used C_mu = beta* = 0.09 for his k-omega model. ---*/
   const su2double C_mu = 0.09;


### PR DESCRIPTION
This is a hotfix for the SST hybrid model.  The SST variable class had a member function that was not overriding the base class virtual function.  This fixes serious problems in the hybrid behavior for SST.