### PR TITLE
Pecos experimental

### DIFF
--- a/SU2_CFD/src/numerics_direct_turbulent.cpp
+++ b/SU2_CFD/src/numerics_direct_turbulent.cpp
@@ -1247,8 +1247,6 @@ void CSourcePieceWise_TurbSST::ComputeResidual(su2double *val_residual, su2doubl
      if (config->GetBoolDivU_inTKEProduction()) {
        SGSProduction -= 2.0/3.0*Density_i*TurbVar_i[0]*diverg;
      }
-     SGSProduction = min(SGSProduction, 20.0*beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]);
-     SGSProduction = max(SGSProduction, 0.0);
 
      /*--- If using a hybrid method, include resolved production ---*/
 
@@ -1260,9 +1258,6 @@ void CSourcePieceWise_TurbSST::ComputeResidual(su2double *val_residual, su2doubl
          const su2double alpha_fac = alpha*(2.0 - alpha);
          SGSProduction     = alpha_fac*Eddy_Viscosity_i*StrainMag_i*StrainMag_i
                              - 2.0/3.0*Density_i*beta*TurbVar_i[0]*diverg;
-
-         SGSProduction = min(SGSProduction, beta*20.0*beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]);
-         SGSProduction = max(SGSProduction, 0.0);
 
          if (config->GetUse_Resolved_Turb_Stress()) {
            su2double pk_resolved = 0;
@@ -1301,6 +1296,11 @@ void CSourcePieceWise_TurbSST::ComputeResidual(su2double *val_residual, su2doubl
        pw = StrainMag_i*StrainMag_i - 2.0/3.0*zeta*diverg;
      }
    }
+
+   /*--- Apply production limiters ---*/
+
+   Production = min(Production, 20.0*beta_star*Density_i*TurbVar_i[1]*TurbVar_i[0]);
+   Production = max(Production, 0.0);
    pw = max(pw,0.0);
 
   // check for nans

--- a/SU2_CFD/src/numerics_direct_turbulent.cpp
+++ b/SU2_CFD/src/numerics_direct_turbulent.cpp
@@ -1294,7 +1294,12 @@ void CSourcePieceWise_TurbSST::ComputeResidual(su2double *val_residual, su2doubl
    if (using_uq){
     pw = PerturbedStrainMag * PerturbedStrainMag - 2.0/3.0*zeta*diverg;
    } else {
-     pw = StrainMag_i*StrainMag_i - 2.0/3.0*zeta*diverg;
+     if (config->GetKind_HybridRANSLES() == MODEL_SPLIT) {
+       /*--- This is just Pk/ mu_t.  Density and alfa_blended are added later. ---*/
+       pw = Production/max(Eddy_Viscosity_i, 1E-8*Laminar_Viscosity_i);
+     } else {
+       pw = StrainMag_i*StrainMag_i - 2.0/3.0*zeta*diverg;
+     }
    }
    pw = max(pw,0.0);
 


### PR DESCRIPTION
This encompasses a few bug fixes w.r.t. the hybrid model.

+ A correction was applied to the modeled mean kinetic energy, since it uses the mean density and not the resolved density
+ Production is limited in the numerics, rather than limiting it before it enters the averaging.
+ The Omega equation now uses the same production as the k equation, to ensure they are still consistent with each other.