### PR TITLE
Reduce the number of default output variables

### DIFF
--- a/Common/include/config_structure.hpp
+++ b/Common/include/config_structure.hpp
@@ -798,6 +798,7 @@ private:
   Wrt_SharpEdges,              /*!< \brief Write residuals to solution file */
   Wrt_Halo,                   /*!< \brief Write rind layers in solution files */
   Wrt_Resolution_Tensors,     /*!< \brief Write resolutions tensors in solution files */
+  Wrt_Fluct_Eddy_Visc,        /*!< \brief Write fluctuating modeled eddy viscosity in solution files */
   Wrt_Reynolds_Stress,        /*!< \brief Write Reynolds stress in solution files */
   Wrt_InvalidState,           /*!< \brief Output the solution due to an invalid state error */
   Wrt_Performance,            /*!< \brief Write the performance summary at the end of a calculation.  */
@@ -3373,6 +3374,12 @@ public:
    * \return <code>TRUE</code> means that resolution tensors will be written to the solution file.
    */
   bool GetWrt_Resolution_Tensors(void);
+
+  /*!
+   * \brief Check if we want to write the eddy viscosity for the fluctuating modeled stress.
+   * \return <code>TRUE</code> if we want to write fluctuating eddy viscosity.
+   */
+  bool GetWrt_Fluct_Eddy_Visc(void) const { return Wrt_Fluct_Eddy_Visc; };
 
   /*!
    * \brief Check if we want to write the Reynolds stress.

--- a/Common/src/config_structure.cpp
+++ b/Common/src/config_structure.cpp
@@ -1835,6 +1835,8 @@ void CConfig::SetConfig_Options(unsigned short val_iZone, unsigned short val_nZo
   addBoolOption("WRT_HALO", Wrt_Halo, false);
   /* DESCRIPTION: Output the resolution tensors in the solution files  \ingroup Config*/
   addBoolOption("WRT_RESOLUTION_TENSORS", Wrt_Resolution_Tensors, false);
+  /* DESCRIPTION: Output the eddy viscosity for the fluctuating modeled stress \ingroup Config */
+  addBoolOption("WRT_FLUCT_EDDY_VISC", Wrt_Fluct_Eddy_Visc, false);
   /* DESCRIPTION: Output the Reynolds stress \ingroup Config */
   addBoolOption("WRT_REYNOLDS_STRESS", Wrt_Reynolds_Stress, false);
   /* DESCRIPTION: Output the performance summary to the console at the end of SU2_CFD  \ingroup Config*/

--- a/SU2_CFD/include/output_structure.hpp
+++ b/SU2_CFD/include/output_structure.hpp
@@ -178,7 +178,7 @@ class COutput {
   vector<string> Variable_Names;
 
   su2double **Data;
-  unsigned short nVar_Consv, nVar_Total, nVar_Extra, nZones;
+  unsigned short nVar_Consv, nVar_Avg, nVar_Total, nVar_Extra, nZones;
   bool wrote_surf_file, wrote_CGNS_base, wrote_Tecplot_base, wrote_Paraview_base;
   unsigned short wrote_base_file;
   su2double RhoRes_New, *RhoRes_Old;

--- a/SU2_CFD/src/driver_structure.cpp
+++ b/SU2_CFD/src/driver_structure.cpp
@@ -1509,9 +1509,6 @@ void CDriver::Solver_Preprocessing(CSolver ****solver_container, CGeometry ***ge
       config->GetKind_Averaging() != NO_AVERAGING) {
     for (iMGlevel = 0; iMGlevel <= config->GetnMGLevels(); iMGlevel++) {
       solver_container[val_iInst][iMGlevel][FLOW_SOL]->InitAverages();
-      if (turbulent) {
-        solver_container[val_iInst][iMGlevel][TURB_SOL]->InitAverages();
-      }
     }
   }
 

--- a/SU2_CFD/src/output_cgns.cpp
+++ b/SU2_CFD/src/output_cgns.cpp
@@ -435,7 +435,7 @@ void COutput::SetCGNS_Solution(CConfig *config, CGeometry *geometry, unsigned sh
   
   /*--- Write averages to CGNS file ---*/
   if (config->GetKind_Averaging() != NO_AVERAGING) {
-    for (jVar = 0; jVar < nVar_Consv; jVar++) {
+    for (jVar = 0; jVar < nVar_Avg; jVar++) {
       name.str(string()); name << "Average " << jVar+1;
       cgns_err = cg_field_write(cgns_file, cgns_base, cgns_zone, cgns_flow, RealDouble,(char *)name.str().c_str(), Data[iVar], &cgns_field); iVar++;
       if (cgns_err) cg_error_print();

--- a/SU2_CFD/src/output_structure.cpp
+++ b/SU2_CFD/src/output_structure.cpp
@@ -492,8 +492,6 @@ void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
                        &CVariable::GetSGSProduction, iZone, true);
         RegisterScalar("trace_mu_SGET", "trace_mu_SGET", FLOW_SOL,
                        &CVariable::GetTraceAnisoEddyViscosity, iZone);
-        RegisterTensor("mu_SGET", "mu<sup>SGET</sup>", FLOW_SOL,
-                       &CVariable::GetAnisoEddyViscosity, iZone);
         RegisterScalar("r_M", "r<sub>M</sub>", FLOW_SOL,
                        &CVariable::GetResolutionAdequacy, iZone, false);
         RegisterScalar("Average_r_M", "avgr<sub>M</sub>", FLOW_SOL,
@@ -506,6 +504,11 @@ void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
                        &CVariable::GetForcingFactor, iZone, false);
         RegisterScalar("ForcingClipping", "ForcingClipping", FLOW_SOL,
                        &CVariable::GetForcingClipping, iZone, false);
+        
+        if (config[iZone]->GetWrt_Fluct_Turb_Stress()) {
+          RegisterTensor("mu_SGET", "mu<sup>SGET</sup>", FLOW_SOL,
+                        &CVariable::GetAnisoEddyViscosity, iZone);
+        }
         if (config[iZone]->GetUse_Resolved_Turb_Stress()) {
           RegisterTensor("tau_res", "tau<sup>res</sup>", FLOW_SOL,
                          &CVariable::GetResolvedTurbStress, iZone, true);
@@ -514,15 +517,6 @@ void COutput::RegisterAllVariables(CConfig** config, unsigned short val_nZone) {
           RegisterTensor("tau_S", "tau_S", FLOW_SOL,
                          &CVariable::GetReynoldsStress, iZone, true);
         }
-        // TODO: Re-incarnate output associated with forcing
-        // RegisterScalar("Forcing_Production", "P<sub>F</sub>", TURB_SOL,
-        //                &CVariable::GetForcingProduction, iZone);
-        // RegisterScalar("Forcing_Ratio", "P<sub>F</sub>", HYBRID_SOL,
-        //                &CVariable::GetForcingRatio, iZone);
-        // RegisterScalar("S_alpha", "S<sub>a</sub>", HYBRID_SOL,
-        //                &CVariable::GetSAlpha, iZone);
-        // RegisterScalar("S_cf", "S<sub>cf</sub>", HYBRID_SOL,
-        //                &CVariable::GetScf, iZone);
       }
     }
   }

--- a/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
+++ b/SU2_CFD/src/solver_direct_turbulent_v2f.cpp
@@ -57,7 +57,6 @@ CTurbKESolver::CTurbKESolver(CGeometry *geometry, CConfig *config,
   unsigned long iPoint;
   ifstream restart_file;
   string text_line;
-  const bool runtime_averaging = (config->GetKind_Averaging() != NO_AVERAGING);
 
   /*--- Array initialization ---*/
   constants = NULL;
@@ -78,9 +77,6 @@ CTurbKESolver::CTurbKESolver(CGeometry *geometry, CConfig *config,
   /*--- Define geometry constants in the solver structure ---*/
   nDim = geometry->GetnDim();
   node = new CVariable*[nPoint];
-  if (runtime_averaging) {
-    average_node = new CVariable*[nPoint];
-  }
 
   /*--- Single grid simulation ---*/
   if (iMesh == MESH_0) {
@@ -262,23 +258,11 @@ CTurbKESolver::CTurbKESolver(CGeometry *geometry, CConfig *config,
                                        muT_Inf, Tm_Inf, Lm_Inf,
                                        nDim, nVar, config);
 
-  if (runtime_averaging) {
-    for (iPoint = 0; iPoint < nPoint; iPoint++) {
-      average_node[iPoint] =
-          new CTurbKEVariable(kine_Inf, epsi_Inf, zeta_Inf, f_Inf, muT_Inf,
-                              Tm_Inf, Lm_Inf, nDim, nVar, config);
-    }
-  }
-
   /*--- MPI solution ---*/
 
   //TODO fix order of comunication the periodic should be first otherwise you have wrong values on the halo cell after restart
   Set_MPI_Solution(geometry, config);
   Set_MPI_Solution(geometry, config);
-  if (runtime_averaging) {
-    Set_MPI_Average_Solution(geometry, config);
-    Set_MPI_Average_Solution(geometry, config);
-  }
 
   /*--- Initializate quantities for SlidingMesh Interface ---*/
 

--- a/config_template.cfg
+++ b/config_template.cfg
@@ -1511,7 +1511,13 @@ WRT_SHARPEDGES= NO
 WRT_SURFACE= NO
 %
 % Output the resolution tensor in the solution files
-WRT_RESOLUTION_TENSORS= YES
+WRT_RESOLUTION_TENSORS= NO
+%
+% Output the resolution tensor in the solution files
+WRT_REYNOLDS_STRESS= NO
+%
+% Output the eddy viscosity from the fluctuating stress model
+WRT_FLUCT_EDDY_VISC= NO
 %
 % Minimize the required output memory
 LOW_MEMORY_OUTPUT= NO


### PR DESCRIPTION
Two main changes:

+ Remove anisotropic eddy viscosity output as a default (trace still left as output)
+ Remove redundant and unused averaging in the turbulence solver